### PR TITLE
harden db

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -47,7 +47,7 @@ pub trait DbOps {
 
     fn insert_named_txs(&self, named_txs: Vec<NamedTx>) -> Result<()>;
 
-    fn get_named_tx(&self, name: &str) -> Result<(TxHash, Option<Address>)>;
+    fn get_named_tx(&self, name: &str) -> Result<NamedTx>;
 
     fn insert_run_txs(&self, run_id: u64, run_txs: Vec<RunTx>) -> Result<()>;
 
@@ -73,8 +73,8 @@ impl DbOps for MockDb {
         Ok(())
     }
 
-    fn get_named_tx(&self, _name: &str) -> Result<(TxHash, Option<Address>)> {
-        Ok((TxHash::default(), None))
+    fn get_named_tx(&self, _name: &str) -> Result<NamedTx> {
+        Ok(NamedTx::new(String::default(), TxHash::default(), None))
     }
 
     fn insert_run_txs(&self, _run_id: u64, _run_txs: Vec<RunTx>) -> Result<()> {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -14,6 +14,29 @@ pub struct RunTx {
     pub gas_used: u128,
 }
 
+#[derive(Debug, Serialize, Clone)]
+pub struct NamedTx {
+    pub name: String,
+    pub tx_hash: TxHash,
+    pub address: Option<Address>,
+}
+
+impl NamedTx {
+    pub fn new(name: String, tx_hash: TxHash, address: Option<Address>) -> Self {
+        Self {
+            name,
+            tx_hash,
+            address,
+        }
+    }
+}
+
+impl From<NamedTx> for Vec<NamedTx> {
+    fn from(named_tx: NamedTx) -> Self {
+        vec![named_tx]
+    }
+}
+
 pub trait DbOps {
     fn create_tables(&self) -> Result<()>;
 
@@ -22,18 +45,9 @@ pub trait DbOps {
 
     fn num_runs(&self) -> Result<u64>;
 
-    fn insert_named_tx(
-        &self,
-        name: String,
-        tx_hash: TxHash,
-        contract_address: Option<Address>,
-    ) -> Result<()>;
-
-    fn insert_named_txs(&self, named_txs: Vec<(String, TxHash, Option<Address>)>) -> Result<()>;
+    fn insert_named_txs(&self, named_txs: Vec<NamedTx>) -> Result<()>;
 
     fn get_named_tx(&self, name: &str) -> Result<(TxHash, Option<Address>)>;
-
-    fn insert_run_tx(&self, run_id: u64, tx: RunTx) -> Result<()>;
 
     fn insert_run_txs(&self, run_id: u64, run_txs: Vec<RunTx>) -> Result<()>;
 
@@ -55,25 +69,12 @@ impl DbOps for MockDb {
         Ok(0)
     }
 
-    fn insert_named_tx(
-        &self,
-        _name: String,
-        _tx_hash: TxHash,
-        _contract_address: Option<Address>,
-    ) -> Result<()> {
-        Ok(())
-    }
-
-    fn insert_named_txs(&self, _named_txs: Vec<(String, TxHash, Option<Address>)>) -> Result<()> {
+    fn insert_named_txs(&self, _named_txs: Vec<NamedTx>) -> Result<()> {
         Ok(())
     }
 
     fn get_named_tx(&self, _name: &str) -> Result<(TxHash, Option<Address>)> {
         Ok((TxHash::default(), None))
-    }
-
-    fn insert_run_tx(&self, _run_id: u64, _tx: RunTx) -> Result<()> {
-        Ok(())
     }
 
     fn insert_run_txs(&self, _run_id: u64, _run_txs: Vec<RunTx>) -> Result<()> {

--- a/src/generator/templater.rs
+++ b/src/generator/templater.rs
@@ -61,7 +61,7 @@ where
             placeholder_map.insert(
                 template_key,
                 template_value
-                    .1
+                    .address
                     .map(|a| self.encode_contract_address(&a))
                     .unwrap_or_default(),
             );

--- a/testfile/src/lib.rs
+++ b/testfile/src/lib.rs
@@ -261,7 +261,7 @@ pub mod tests {
 
     #[test]
     fn parses_testconfig_toml() {
-        let test_file = TestConfig::from_file("univ2ConfigTest.toml").unwrap();
+        let test_file = TestConfig::from_file("../cli/univ2ConfigTest.toml").unwrap();
         assert!(test_file.env.is_some());
         assert!(test_file.setup.is_some());
         assert!(test_file.spam.is_some());


### PR DESCRIPTION
- add `struct NamedTx` to `db` module
- remove singular insert functions (favor plural versions) from `trait DbOps`
- return `NamedTx` from `get_named_tx`

also fixes a broken test