### PR TITLE
prvkey ux improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contender is a high-performance Ethereum network spammer and testing tool design
 To install the Contender CLI, you need to have the [Rust toolchain](https://rustup.rs/) installed on your system. Then build the project from source:
 
 ```bash
-git clone https://github.com/zeroxbrock/contender.git
+git clone https://github.com/flashbots/contender.git
 cd contender/cli
 cargo build --release
 alias contender="$PWD/target/release/contender_cli"
@@ -48,9 +48,9 @@ To use Contender as a library in your Rust project, add the crates you need to y
 ```toml
 [dependencies]
 ...
-contender = { git = "https://github.com/zeroxbrock/contender" }
-contender_sqlite = { git = "https://github.com/zeroxbrock/contender" }
-contender_testfile = { git = "https://github.com/zeroxbrock/contender" }
+contender = { git = "https://github.com/flashbots/contender" }
+contender_sqlite = { git = "https://github.com/flashbots/contender" }
+contender_testfile = { git = "https://github.com/flashbots/contender" }
 # not necessarily required, but recommended:
 tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 ```

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -74,6 +74,14 @@ May be specified multiple times."
             visible_aliases = &["dr"]
         )]
         disable_reports: bool,
+
+        /// The minimum balance to check for each private key.
+        #[arg(
+            long,
+            long_help = "The minimum balance to check for each private key in decimal-ETH format (`--min-balance 1.5` means 1.5 * 1e18 wei).",
+            default_value = "1.0"
+        )]
+        min_balance: String,
     },
 
     #[command(
@@ -95,6 +103,14 @@ May be specified multiple times."
 May be specified multiple times."
         )]
         private_keys: Option<Vec<String>>,
+
+        /// The minimum balance to check for each private key.
+        #[arg(
+            long,
+            long_help = "The minimum balance to check for each private key in decimal-ETH format (ex: `--min-balance 1.5` means 1.5 * 1e18 wei).",
+            default_value = "1.0"
+        )]
+        min_balance: String,
     },
 
     #[command(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -116,6 +116,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if txs_per_block.is_some() && txs_per_second.is_some() {
                 panic!("Cannot set both --txs-per-block and --txs-per-second");
             }
+            if txs_per_block.is_none() && txs_per_second.is_none() {
+                panic!("Must set either --txs-per-block (--tpb) or --txs-per-second (--tps)");
+            }
 
             if let Some(txs_per_block) = txs_per_block {
                 let scenario =


### PR DESCRIPTION
Adds checks at the start of setup & spam commands:
- sufficient balance (default 1 ETH; can be overridden by `--min-balance`)
- user passed all private keys used in the given config file

Also added all the default keys from anvil/hardhat, so the default examples will work with no private keys passed.