### PR TITLE
support non-eth rpc providers

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 
 use alloy::{
+    network::AnyNetwork,
     primitives::{
         utils::{format_ether, parse_ether},
         Address, U256,
@@ -13,7 +14,7 @@ use commands::{ContenderCli, ContenderSubcommand};
 use contender_core::{
     db::{DbOps, RunTx},
     generator::{
-        types::{FunctionCallDefinition, RpcProvider},
+        types::{AnyProvider, FunctionCallDefinition},
         RandSeed,
     },
     spammer::{BlockwiseSpammer, LogCallback, NilCallback, TimedSpammer},
@@ -63,7 +64,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             min_balance,
         } => {
             let url = Url::parse(rpc_url.as_ref()).expect("Invalid RPC URL");
-            let rpc_client = ProviderBuilder::new().on_http(url.to_owned());
+            let rpc_client = ProviderBuilder::new()
+                .network::<AnyNetwork>()
+                .on_http(url.to_owned());
             let testconfig: TestConfig = TestConfig::from_file(&testfile)?;
             let min_balance = parse_ether(&min_balance)?;
 
@@ -101,7 +104,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let testconfig = TestConfig::from_file(&testfile)?;
             let rand_seed = seed.map(|s| RandSeed::from_str(&s)).unwrap_or_default();
             let url = Url::parse(rpc_url.as_ref()).expect("Invalid RPC URL");
-            let rpc_client = ProviderBuilder::new().on_http(url.to_owned());
+            let rpc_client = ProviderBuilder::new()
+                .network::<AnyNetwork>()
+                .on_http(url.to_owned());
             let duration = duration.unwrap_or_default();
             let min_balance = parse_ether(&min_balance)?;
 
@@ -223,7 +228,7 @@ const DEFAULT_PRV_KEYS: [&str; 10] = [
 
 async fn spam_callback_default(
     log_txs: bool,
-    rpc_client: Option<Arc<RpcProvider>>,
+    rpc_client: Option<Arc<AnyProvider>>,
 ) -> SpamCallbackType {
     if let Some(rpc_client) = rpc_client {
         if log_txs {
@@ -236,7 +241,7 @@ async fn spam_callback_default(
 async fn check_balances(
     prv_keys: &[PrivateKeySigner],
     min_balance: U256,
-    rpc_client: &RpcProvider,
+    rpc_client: &AnyProvider,
 ) {
     for prv_key in prv_keys {
         let address = prv_key.address();

--- a/src/generator/types.rs
+++ b/src/generator/types.rs
@@ -1,4 +1,5 @@
 use alloy::{
+    network::AnyNetwork,
     primitives::U256,
     providers::RootProvider,
     rpc::types::TransactionRequest,
@@ -8,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
-pub type RpcProvider = RootProvider<Http<Client>>;
+pub type EthProvider = RootProvider<Http<Client>>;
+pub type AnyProvider = RootProvider<Http<Client>, AnyNetwork>;
 
 #[derive(Clone, Debug)]
 pub struct NamedTxRequest {

--- a/src/spammer/blockwise.rs
+++ b/src/spammer/blockwise.rs
@@ -2,12 +2,12 @@ use crate::db::DbOps;
 use crate::error::ContenderError;
 use crate::generator::seeder::Seeder;
 use crate::generator::templater::Templater;
-use crate::generator::types::{PlanType, RpcProvider};
+use crate::generator::types::{AnyProvider, EthProvider, PlanType};
 use crate::generator::{Generator, PlanConfig};
 use crate::test_scenario::TestScenario;
 use crate::Result;
 use alloy::hex::ToHexExt;
-use alloy::network::TransactionBuilder;
+use alloy::network::{AnyNetwork, TransactionBuilder};
 use alloy::primitives::FixedBytes;
 use alloy::providers::{Provider, ProviderBuilder};
 use futures::StreamExt;
@@ -28,7 +28,8 @@ where
 {
     scenario: TestScenario<D, S, P>,
     msg_handler: Arc<TxActorHandle>,
-    rpc_client: Arc<RpcProvider>,
+    rpc_client: AnyProvider,
+    eth_client: Arc<EthProvider>,
     callback_handler: Arc<F>,
 }
 
@@ -40,17 +41,22 @@ where
     P: PlanConfig<String> + Templater<String> + Send + Sync,
 {
     pub fn new(scenario: TestScenario<D, S, P>, callback_handler: F) -> Self {
-        let rpc_client = Arc::new(ProviderBuilder::new().on_http(scenario.rpc_url.to_owned()));
+        let rpc_client = ProviderBuilder::new()
+            .network::<AnyNetwork>()
+            .on_http(scenario.rpc_url.to_owned());
+        let eth_client = Arc::new(ProviderBuilder::new().on_http(scenario.rpc_url.to_owned()));
         let msg_handler = Arc::new(TxActorHandle::new(
             12,
             scenario.db.clone(),
-            rpc_client.clone(),
+            Arc::new(rpc_client.to_owned()),
         ));
+        let callback_handler = Arc::new(callback_handler);
 
         Self {
             scenario,
             rpc_client,
-            callback_handler: Arc::new(callback_handler),
+            eth_client,
+            callback_handler,
             msg_handler,
         }
     }
@@ -165,7 +171,7 @@ where
 
                 if !gas_limits.contains_key(fn_sig.as_slice()) {
                     let gas_limit = self
-                        .rpc_client
+                        .eth_client
                         .estimate_gas(&tx.tx.to_owned())
                         .await
                         .map_err(|e| ContenderError::with_err(e, "failed to estimate gas"))?;
@@ -173,7 +179,7 @@ where
                 }
 
                 // clone muh Arcs
-                let rpc_client = self.rpc_client.clone();
+                let eth_client = self.eth_client.clone();
                 let callback_handler = self.callback_handler.clone();
 
                 // query hashmaps for gaslimit & signer of this tx
@@ -193,7 +199,7 @@ where
                 tasks.push(task::spawn(async move {
                     let provider = ProviderBuilder::new()
                         .wallet(signer)
-                        .on_provider(rpc_client);
+                        .on_provider(eth_client);
 
                     let full_tx = tx_req
                         .clone()

--- a/src/spammer/mod.rs
+++ b/src/spammer/mod.rs
@@ -3,8 +3,8 @@ pub mod timed;
 pub mod tx_actor;
 pub mod util;
 
-use crate::generator::{types::RpcProvider, NamedTxRequest};
-use alloy::providers::{PendingTransactionBuilder, PendingTransactionConfig};
+use crate::generator::{types::AnyProvider, NamedTxRequest};
+use alloy::providers::PendingTransactionConfig;
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::JoinHandle;
 use tx_actor::TxActorHandle;
@@ -35,11 +35,11 @@ impl NilCallback {
 }
 
 pub struct LogCallback {
-    pub rpc_provider: Arc<RpcProvider>,
+    pub rpc_provider: Arc<AnyProvider>,
 }
 
 impl LogCallback {
-    pub fn new(rpc_provider: Arc<RpcProvider>) -> Self {
+    pub fn new(rpc_provider: Arc<AnyProvider>) -> Self {
         Self { rpc_provider }
     }
 }
@@ -65,18 +65,15 @@ impl OnTxSent for LogCallback {
         extra: Option<HashMap<String, String>>,
         tx_actor: Option<Arc<TxActorHandle>>,
     ) -> Option<JoinHandle<()>> {
-        let rpc = self.rpc_provider.clone();
         let start_timestamp = extra
             .as_ref()
             .map(|e| e.get("start_timestamp").map(|t| t.parse::<usize>()))
             .flatten()?
             .unwrap_or(0);
         let handle = tokio::task::spawn(async move {
-            let res = PendingTransactionBuilder::from_config(&rpc, tx_response);
-            let tx_hash = res.tx_hash();
             if let Some(tx_actor) = tx_actor {
                 tx_actor
-                    .cache_run_tx(*tx_hash, start_timestamp)
+                    .cache_run_tx(*tx_response.tx_hash(), start_timestamp)
                     .await
                     .expect("failed to cache run tx");
             }

--- a/src/spammer/timed.rs
+++ b/src/spammer/timed.rs
@@ -3,7 +3,7 @@ use crate::{
     generator::{
         seeder::Seeder,
         templater::Templater,
-        types::{PlanType, RpcProvider},
+        types::{EthProvider, PlanType},
         Generator, PlanConfig,
     },
     spammer::OnTxSent,
@@ -24,7 +24,7 @@ where
     P: PlanConfig<String> + Templater<String> + Send + Sync,
 {
     scenario: TestScenario<D, S, P>,
-    rpc_client: Arc<RpcProvider>,
+    rpc_client: Arc<EthProvider>,
     callback_handler: Arc<F>,
 }
 

--- a/src/spammer/tx_actor.rs
+++ b/src/spammer/tx_actor.rs
@@ -6,7 +6,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::{
     db::{DbOps, RunTx},
     error::ContenderError,
-    generator::types::RpcProvider,
+    generator::types::AnyProvider,
 };
 
 enum TxActorMessage {
@@ -29,7 +29,7 @@ where
     receiver: mpsc::Receiver<TxActorMessage>,
     db: Arc<D>,
     cache: Vec<PendingRunTx>,
-    rpc: Arc<RpcProvider>,
+    rpc: Arc<AnyProvider>,
 }
 
 #[derive(Clone, PartialEq)]
@@ -54,7 +54,7 @@ where
     pub fn new(
         receiver: mpsc::Receiver<TxActorMessage>,
         db: Arc<D>,
-        rpc: Arc<RpcProvider>,
+        rpc: Arc<AnyProvider>,
     ) -> Self {
         Self {
             receiver,
@@ -176,7 +176,7 @@ impl TxActorHandle {
     pub fn new<D: DbOps + Send + Sync + 'static>(
         bufsize: usize,
         db: Arc<D>,
-        rpc: Arc<RpcProvider>,
+        rpc: Arc<AnyProvider>,
     ) -> Self {
         let (sender, receiver) = mpsc::channel(bufsize);
         let mut actor = TxActor::new(receiver, db, rpc);

--- a/src/test_scenario.rs
+++ b/src/test_scenario.rs
@@ -154,7 +154,7 @@ where
                 let wallet = ProviderBuilder::new()
                     .with_simple_nonce_management()
                     .wallet(wallet)
-                    .on_http(rpc_url.to_owned());
+                    .on_http(rpc_url);
 
                 let chain_id = wallet.get_chain_id().await.expect("failed to get chain id");
                 let gas_price = wallet


### PR DESCRIPTION
If a block on the target RPC contained a tx receipt with a non-standard type, or some other field that isn't present on base ethereum, deserialization would fail and crash the spammer.

To fix this, I generalized the expected response type (where relevant), by using `AnyNetwork` as our provider's network type (where relevant).
- new type alias `AnyProvider` replaces `RpcProvider` in several places (but not all)
- type that was `RpcProvider` renamed to `EthProvider`

`EthProvider` is used to do things we can't do with `AnyProvider`, like signing txs & estimating gas.