### PR TITLE
differentiate seed using pool name, fix account index bug

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -151,7 +151,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     continue;
                 }
 
-                let agent = SignerStore::new_random(signers_per_block, &rand_seed);
+                let agent = SignerStore::new_random(signers_per_block, &rand_seed, &from_pool);
                 all_signers.extend_from_slice(&agent.signers);
                 agents.add_agent(from_pool, agent);
             }

--- a/crates/core/src/agent_controller.rs
+++ b/crates/core/src/agent_controller.rs
@@ -19,6 +19,7 @@ pub trait AgentRegistry<Index: Ord> {
     fn get_agent(&self, idx: Index) -> Option<&Address>;
 }
 
+#[derive(Debug)]
 pub struct SignerStore {
     pub signers: Vec<PrivateKeySigner>,
 }

--- a/crates/core/src/agent_controller.rs
+++ b/crates/core/src/agent_controller.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use alloy::{
-    primitives::{Address, FixedBytes},
+    primitives::{Address, FixedBytes, U256},
     signers::local::PrivateKeySigner,
 };
 
@@ -50,7 +50,7 @@ impl AgentStore {
         num_signers: usize,
         rand_seeder: &RandSeed,
     ) {
-        let signers = SignerStore::new_random(num_signers, rand_seeder);
+        let signers = SignerStore::new_random(num_signers, rand_seeder, name.as_ref());
         self.add_agent(name, signers);
     }
 
@@ -91,7 +91,12 @@ impl SignerStore {
         }
     }
 
-    pub fn new_random(num_signers: usize, rand_seeder: &RandSeed) -> Self {
+    pub fn new_random(num_signers: usize, rand_seeder: &RandSeed, acct_seed: &str) -> Self {
+        // add numerical value of acct_seed to given seed
+        let new_seed = rand_seeder.as_u256() + U256::from_be_slice(acct_seed.as_bytes());
+        let rand_seeder = RandSeed::from_u256(new_seed);
+
+        // generate random private keys with new seed
         let prv_keys = rand_seeder
             .seed_values(num_signers, None, None)
             .map(|sv| sv.as_bytes().to_vec())

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -270,6 +270,15 @@ where
                     };
                 }
 
+                let agentstore = self.get_agent_store();
+                let num_accts = agentstore
+                    .all_agents()
+                    .next()
+                    .expect("agent has no signers")
+                    .1
+                    .signers
+                    .len();
+
                 for i in 0..(num_txs / num_steps) {
                     for step in spam_steps.iter() {
                         // converts a FunctionCallDefinition to a NamedTxRequest (filling in fuzzable args),
@@ -286,7 +295,7 @@ where
 
                             let tx = NamedTxRequest::new(
                                 templater.template_function_call(
-                                    &self.make_strict_call(&req, i % num_steps)?, // 'from' address injected here
+                                    &self.make_strict_call(&req, i % num_accts)?, // 'from' address injected here
                                     &placeholder_map,
                                 )?,
                                 None,

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -274,10 +274,8 @@ where
                 let num_accts = agentstore
                     .all_agents()
                     .next()
-                    .expect("agent has no signers")
-                    .1
-                    .signers
-                    .len();
+                    .map(|(_, store)| store.signers.len())
+                    .unwrap_or(1);
 
                 for i in 0..(num_txs / num_steps) {
                     for step in spam_steps.iter() {

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -286,7 +286,7 @@ where
 
                             let tx = NamedTxRequest::new(
                                 templater.template_function_call(
-                                    &self.make_strict_call(&req, i)?, // 'from' address injected here
+                                    &self.make_strict_call(&req, i % num_steps)?, // 'from' address injected here
                                     &placeholder_map,
                                 )?,
                                 None,

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -271,7 +271,7 @@ where
                 }
 
                 for i in 0..(num_txs / num_steps) {
-                    for (j, step) in spam_steps.iter().enumerate() {
+                    for step in spam_steps.iter() {
                         // converts a FunctionCallDefinition to a NamedTxRequest (filling in fuzzable args),
                         // returns a callback handle and the processed tx request
                         let process_tx = |req| {
@@ -286,7 +286,7 @@ where
 
                             let tx = NamedTxRequest::new(
                                 templater.template_function_call(
-                                    &self.make_strict_call(&req, j)?, // 'from' address injected here
+                                    &self.make_strict_call(&req, i)?, // 'from' address injected here
                                     &placeholder_map,
                                 )?,
                                 None,

--- a/crates/core/src/spammer/blockwise.rs
+++ b/crates/core/src/spammer/blockwise.rs
@@ -26,7 +26,7 @@ use super::tx_actor::TxActorHandle;
 use super::OnTxSent;
 
 /// Defines the number of blocks to target with a single bundle.
-const BUNDLE_BLOCK_TOLERANCE: usize = 4;
+const BUNDLE_BLOCK_TOLERANCE: usize = 2;
 
 pub struct BlockwiseSpammer<F, D, S, P>
 where
@@ -392,7 +392,7 @@ where
         if let Some(run_id) = run_id {
             loop {
                 timeout_counter += 1;
-                if timeout_counter > 12 {
+                if timeout_counter > BUNDLE_BLOCK_TOLERANCE + 2 {
                     println!("Quitting due to timeout.");
                     break;
                 }

--- a/crates/core/src/spammer/blockwise.rs
+++ b/crates/core/src/spammer/blockwise.rs
@@ -26,7 +26,7 @@ use super::tx_actor::TxActorHandle;
 use super::OnTxSent;
 
 /// Defines the number of blocks to target with a single bundle.
-const BUNDLE_BLOCK_TOLERANCE: usize = 5;
+const BUNDLE_BLOCK_TOLERANCE: usize = 4;
 
 pub struct BlockwiseSpammer<F, D, S, P>
 where
@@ -249,6 +249,7 @@ where
                                 .await
                                 .map_err(|e| ContenderError::with_err(e, "failed to prepare tx"))?;
 
+                            println!("bundle tx from {:?}", tx_req.from);
                             // sign tx
                             let tx_envelope = tx_req.build(&signer).await.map_err(|e| {
                                 ContenderError::with_err(e, "bad request: failed to build tx")

--- a/scenarios/spamMe.toml
+++ b/scenarios/spamMe.toml
@@ -16,7 +16,7 @@ signature = "transfer()"
 [[spam.tx.fuzz]]
 value = true
 min = "10000000000000"
-max = "1000000000000000"
+max = "100000000000000"
 
 
 # spam bundle

--- a/scenarios/spamMe.toml
+++ b/scenarios/spamMe.toml
@@ -26,11 +26,11 @@ max = "100000000000000"
 to = "{SpamMe}"
 from_pool = "bluepool"
 signature = "consumeGas(uint256 gasAmount)"
-args = ["510000"]
-fuzz = [{ param = "gasAmount", min = "100000", max = "500000" }]
+args = ["51000"]
+fuzz = [{ param = "gasAmount", min = "22000", max = "69000" }]
 
 [[spam.bundle.tx]]
 to = "{SpamMe}"
-from_pool = "bluepool"
+from_pool = "greenpool"
 signature = "tipCoinbase()"
 value = "10000000000000000"

--- a/scenarios/spamMe.toml
+++ b/scenarios/spamMe.toml
@@ -31,6 +31,6 @@ fuzz = [{ param = "gasAmount", min = "22000", max = "69000" }]
 
 [[spam.bundle.tx]]
 to = "{SpamMe}"
-from_pool = "greenpool"
+from_pool = "bluepool"
 signature = "tipCoinbase()"
 value = "10000000000000000"


### PR DESCRIPTION
- fixed: same account was being used for every parallel tx sent by an agent (signer pool)
- fixed: same seed was being used for every agent