### PR TITLE
Set `TxType` for scenario txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1317fde6d2d3cd6082a15144c23230697a5e1a91a27d1facc146715d3b4b2046"
+checksum = "996564c1782285d4e0299c29b318bc74f24b1d7f456cef3e040810b061ee3256"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -1237,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1247,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1783,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1895,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2697,9 +2697,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
@@ -2788,9 +2788,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3402,7 +3402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.1",
+ "rand_core 0.9.2",
  "zerocopy 0.8.20",
 ]
 
@@ -3423,7 +3423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.1",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -3437,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
 dependencies = [
  "getrandom 0.3.1",
  "zerocopy 0.8.20",
@@ -3561,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 use std::path::PathBuf;
 
 use crate::default_scenarios::BuiltinScenario;
+use crate::util::TxTypeCli;
 
 #[derive(Debug, Subcommand)]
 pub enum ContenderSubcommand {
@@ -97,6 +98,16 @@ May be specified multiple times."
             long_help = "Filename of the saved report. May be a fully-qualified path. If not provided, the report can be generated with the `report` subcommand. '.csv' extension is added automatically."
         )]
         gen_report: bool,
+
+        /// Transaction type
+        #[arg(
+            short = 't',
+            long,
+            long_help = "Set tx type such as Legacy/Eip1559",
+            value_enum,
+            default_value_t = TxTypeCli::Eip1559,
+        )]
+        tx_type: TxTypeCli,
     },
 
     #[command(
@@ -130,6 +141,16 @@ May be specified multiple times."
         /// The seed used to generate pool accounts.
         #[arg(short, long, long_help = "The seed used to generate pool accounts.")]
         seed: Option<String>,
+
+        /// Transaction type
+        #[arg(
+            short = 't',
+            long,
+            long_help = "Set tx type such as Legacy/Eip1559",
+            value_enum,
+            default_value_t = TxTypeCli::Eip1559,
+        )]
+        tx_type: TxTypeCli,
     },
 
     #[command(
@@ -204,6 +225,16 @@ May be specified multiple times."
             visible_aliases = &["sdp"]
         )]
         skip_deploy_prompt: bool,
+
+        /// Transaction type
+        #[arg(
+            short = 't',
+            long,
+            long_help = "Set tx type such as Legacy/Eip1559",
+            value_enum,
+            default_value_t = TxTypeCli::Eip1559,
+        )]
+        tx_type: TxTypeCli,
         // TODO: DRY duplicate args
     },
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -11,7 +11,7 @@ use contender_core::{
     agent_controller::AgentStore,
     db::DbOps,
     error::ContenderError,
-    generator::RandSeed,
+    generator::{types::TxType, RandSeed},
     spammer::{LogCallback, Spammer, TimedSpammer},
     test_scenario::TestScenario,
 };
@@ -30,6 +30,7 @@ pub struct RunCommandArgs {
     pub duration: usize,
     pub txs_per_duration: usize,
     pub skip_deploy_prompt: bool,
+    pub tx_type: TxType,
 }
 
 pub async fn run(
@@ -61,6 +62,7 @@ pub async fn run(
             args.txs_per_duration as u64,
             admin_signer.address(),
             fill_percent,
+            args.tx_type,
         ),
     };
     let scenario_name = scenario_config.to_string();
@@ -76,6 +78,7 @@ pub async fn run(
         rand_seed,
         &user_signers,
         AgentStore::default(),
+        args.tx_type,
     )
     .await?;
 

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -8,7 +8,7 @@ use alloy::{
 use contender_core::{
     agent_controller::{AgentStore, SignerStore},
     error::ContenderError,
-    generator::RandSeed,
+    generator::{types::TxType, RandSeed},
     test_scenario::TestScenario,
 };
 use contender_testfile::TestConfig;
@@ -26,6 +26,7 @@ pub async fn setup(
     private_keys: Option<Vec<String>>,
     min_balance: String,
     seed: RandSeed,
+    tx_type: TxType,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let url = Url::parse(rpc_url.as_ref()).expect("Invalid RPC URL");
     let rpc_client = DynProvider::new(
@@ -34,7 +35,8 @@ pub async fn setup(
             .on_http(url.to_owned()),
     );
     let eth_client = DynProvider::new(ProviderBuilder::new().on_http(url.to_owned()));
-    let testconfig: TestConfig = TestConfig::from_file(testfile.as_ref())?;
+    let mut testconfig: TestConfig = TestConfig::from_file(testfile.as_ref())?;
+    testconfig.set_req_tx_type(tx_type)?;
     let min_balance = parse_ether(&min_balance)?;
 
     let user_signers = private_keys
@@ -108,6 +110,7 @@ pub async fn setup(
         &rpc_client,
         &eth_client,
         min_balance,
+        tx_type,
     )
     .await?;
 
@@ -119,6 +122,7 @@ pub async fn setup(
         seed,
         &user_signers_with_defaults,
         agents,
+        tx_type,
     )
     .await?;
 

--- a/crates/cli/src/default_scenarios/runconfig.rs
+++ b/crates/cli/src/default_scenarios/runconfig.rs
@@ -1,7 +1,9 @@
 use std::fmt::Display;
 
 use alloy::primitives::Address;
-use contender_core::generator::types::{CreateDefinition, FunctionCallDefinition, SpamRequest};
+use contender_core::generator::types::{
+    CreateDefinition, FunctionCallDefinition, SpamRequest, TxType,
+};
 use contender_testfile::TestConfig;
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +22,7 @@ impl Display for BuiltinScenarioConfig {
                 num_txs: _,
                 sender: _,
                 fill_percent: _,
+                tx_type: _,
             } => write!(f, "fill-block"),
         }
     }
@@ -31,6 +34,7 @@ pub enum BuiltinScenarioConfig {
         num_txs: u64,
         sender: Address,
         fill_percent: u16,
+        tx_type: TxType,
     },
 }
 
@@ -40,12 +44,14 @@ impl BuiltinScenarioConfig {
         num_txs: u64,
         sender: Address,
         fill_percent: u16,
+        tx_type: TxType,
     ) -> Self {
         Self::FillBlock {
             max_gas_per_block,
             num_txs,
             sender,
             fill_percent,
+            tx_type,
         }
     }
 }
@@ -58,6 +64,7 @@ impl From<BuiltinScenarioConfig> for TestConfig {
                 num_txs,
                 sender,
                 fill_percent,
+                tx_type,
             } => {
                 let gas_per_tx = ((max_gas_per_block / num_txs) / 100) * fill_percent as u64;
                 println!(
@@ -76,6 +83,7 @@ impl From<BuiltinScenarioConfig> for TestConfig {
                             fuzz: None,
                             kind: Some("fill-block".to_owned()),
                             gas_limit: None,
+                            tx_type: Some(tx_type),
                         })
                     })
                     .collect::<Vec<_>>();
@@ -87,6 +95,7 @@ impl From<BuiltinScenarioConfig> for TestConfig {
                         bytecode: bytecode::SPAM_ME.to_owned(),
                         from: Some(sender.to_string()),
                         from_pool: None,
+                        tx_type: Some(tx_type),
                     }]),
                     setup: None,
                     spam: Some(spam_txs),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -53,6 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             private_keys,
             min_balance,
             seed,
+            tx_type,
         } => {
             let seed = seed.unwrap_or(stored_seed);
             commands::setup(
@@ -62,6 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 private_keys,
                 min_balance,
                 RandSeed::seed_from_str(&seed),
+                tx_type.into(),
             )
             .await?
         }
@@ -78,6 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             disable_reports,
             min_balance,
             gen_report,
+            tx_type,
         } => {
             let seed = seed.unwrap_or(stored_seed);
             let run_id = commands::spam(
@@ -93,6 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     private_keys,
                     disable_reports,
                     min_balance,
+                    tx_type: tx_type.into(),
                 },
             )
             .await?;
@@ -117,6 +121,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             duration,
             txs_per_duration,
             skip_deploy_prompt,
+            tx_type,
         } => {
             commands::run(
                 &db,
@@ -128,6 +133,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     duration,
                     txs_per_duration,
                     skip_deploy_prompt,
+                    tx_type: tx_type.into(),
                 },
             )
             .await?

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -18,7 +18,7 @@ use named_txs::ExecutionRequest;
 pub use named_txs::NamedTxRequestBuilder;
 pub use seeder::rand_seed::RandSeed;
 use std::{collections::HashMap, fmt::Debug, hash::Hash};
-use types::{CreateDefinitionStrict, FunctionCallDefinitionStrict, SpamRequest};
+use types::{CreateDefinitionStrict, FunctionCallDefinitionStrict, SpamRequest, TxType};
 
 pub use types::{CallbackResult, NamedTxRequest, PlanType};
 
@@ -162,10 +162,13 @@ where
             .to_owned()
             .replace("{_sender}", &from_address.encode_hex()); // inject address WITHOUT 0x prefix
 
+        let tx_type = create_def.tx_type.unwrap_or(TxType::Eip1559);
+
         Ok(CreateDefinitionStrict {
             name: create_def.name.to_owned(),
             bytecode,
             from: from_address,
+            tx_type: tx_type,
         })
     }
 
@@ -229,6 +232,7 @@ where
             fuzz: funcdef.fuzz.to_owned().unwrap_or_default(),
             kind: funcdef.kind.to_owned(),
             gas_limit: funcdef.gas_limit.to_owned(),
+            tx_type: funcdef.tx_type.unwrap_or(TxType::Eip1559),
         })
     }
 

--- a/crates/core/src/generator/templater.rs
+++ b/crates/core/src/generator/templater.rs
@@ -133,6 +133,7 @@ where
             from: Some(funcdef.from),
             value,
             gas: funcdef.gas_limit,
+            transaction_type: Some(funcdef.tx_type as u8),
             ..Default::default()
         })
     }
@@ -149,6 +150,7 @@ where
             input: alloy::rpc::types::TransactionInput::both(
                 Bytes::from_hex(&full_bytecode).expect("invalid bytecode hex"),
             ),
+            transaction_type: Some(createdef.tx_type as u8),
             ..Default::default()
         };
         Ok(tx)

--- a/crates/core/src/spammer/blockwise.rs
+++ b/crates/core/src/spammer/blockwise.rs
@@ -56,6 +56,7 @@ mod tests {
         providers::{DynProvider, ProviderBuilder},
     };
 
+    use crate::generator::types::TxType;
     use crate::{
         agent_controller::{AgentStore, SignerStore},
         db::MockDb,
@@ -78,6 +79,7 @@ mod tests {
         let mut agents = AgentStore::new();
         let txs_per_period = 10;
         let periods = 3;
+        let tx_type = TxType::Legacy;
         agents.add_agent(
             "pool1",
             SignerStore::new_random(txs_per_period / periods, &seed, "eeeeeeee"),
@@ -101,6 +103,7 @@ mod tests {
                     U256::from(ETH_TO_WEI),
                     &provider,
                     Some(nonce),
+                    tx_type,
                 )
                 .await
                 .unwrap();
@@ -118,6 +121,7 @@ mod tests {
             seed,
             &user_signers,
             agents,
+            tx_type,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Hi, this is a great perf tool. I found that spammer sends EIP-1559 txs by default, which is fine, but sometimes eth-forked/custom node clients may not support EIP-1559 and therefore it is needed to be specified to send legacy txs.
So this PR adds the `legacy` option to specify sending legacy txs.

please review and feel free to comment.
