### PR TITLE
save default file on report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 cargotest.toml
 *.db
+report.csv

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -33,10 +33,15 @@ pub fn report(
         let mut writer = WriterBuilder::new().has_headers(true).from_path(out_file)?;
         write_run_txs(&mut writer, &txs)?;
     } else {
+        // print to stdout and write to default file
         let mut writer = WriterBuilder::new()
             .has_headers(true)
             .from_writer(std::io::stdout());
         write_run_txs(&mut writer, &txs)?; // TODO: write a macro that lets us generalize the writer param to write_run_txs, then refactor this duplication
+        let mut writer = WriterBuilder::new()
+            .has_headers(true)
+            .from_path("report.csv")?;
+        write_run_txs(&mut writer, &txs)?;
     };
 
     Ok(())

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -38,10 +38,15 @@ pub fn report(
             .has_headers(true)
             .from_writer(std::io::stdout());
         write_run_txs(&mut writer, &txs)?; // TODO: write a macro that lets us generalize the writer param to write_run_txs, then refactor this duplication
+        let home_dir = std::env::var("HOME").expect("Could not get home directory");
+        let contender_dir = format!("{}/.contender", home_dir);
+        std::fs::create_dir_all(&contender_dir)?;
+        let report_path = format!("{}/report.csv", contender_dir);
         let mut writer = WriterBuilder::new()
             .has_headers(true)
-            .from_path("report.csv")?;
+            .from_path(report_path.to_owned())?;
         write_run_txs(&mut writer, &txs)?;
+        println!("saved report to {}", report_path);
     };
 
     Ok(())

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -44,7 +44,7 @@ pub fn report(
         let report_path = format!("{}/report.csv", contender_dir);
         let mut writer = WriterBuilder::new()
             .has_headers(true)
-            .from_path(report_path.to_owned())?;
+            .from_path(&report_path)?;
         write_run_txs(&mut writer, &txs)?;
         println!("saved report to {}", report_path);
     };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,7 +9,15 @@ use contender_core::{db::DbOps, generator::RandSeed};
 use contender_sqlite::SqliteDb;
 
 static DB: LazyLock<SqliteDb> = std::sync::LazyLock::new(|| {
-    SqliteDb::from_file("contender.db").expect("failed to open contender.db")
+    let path = &format!(
+        "{}{}",
+        std::env::var("HOME").unwrap(),
+        "/.contender/contender.db"
+    );
+    println!("opening DB at {}", path);
+    std::fs::create_dir_all(std::env::var("HOME").unwrap() + "/.contender")
+        .expect("failed to create ~/.contender directory");
+    SqliteDb::from_file(path).expect("failed to open contender DB file")
 });
 
 #[tokio::main]

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -165,7 +165,7 @@ where
                         }
                         RunTx {
                             tx_hash: pending_tx.tx_hash,
-                            start_timestamp: pending_tx.start_timestamp,
+                            start_timestamp: pending_tx.start_timestamp / 1000,
                             end_timestamp: target_block.header.timestamp as usize,
                             block_number: target_block.header.number,
                             gas_used: receipt.gas_used,


### PR DESCRIPTION
- **export report to report.csv by default**
- **fix ms-sec logging in report**
- save reports to `~/.contender/report.csv` by default
- keep DB in `~/.contender/contender.db`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

should be able to run `contender report` with no args and get the latest report saved to `report.csv`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes