### PR TITLE
create, save, and load user seed: ~/.contender/seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "contender_sqlite",
  "contender_testfile",
  "csv",
+ "rand",
  "serde",
  "termcolor",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [ "crates/bundle_provider",
 resolver = "2"
 
 [workspace.package]
-# name = "contender"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.80"
@@ -28,13 +27,13 @@ contender_bundle_provider = { path = "crates/bundle_provider/" }
 tokio = { version = "1.40.0" }
 alloy = { version = "0.3.6" }
 serde = "1.0.209"
+rand = "0.8.5"
 
 ## cli
 clap = { version = "4.5.16" }
 csv = "1.3.0"
 
 ## core
-rand = "0.8.5"
 futures = "0.3.30"
 async-trait = "0.1.82"
 jsonrpsee = { version = "0.24" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,3 +18,4 @@ clap = { workspace = true, features = ["derive"] }
 alloy = { workspace = true, features = ["full", "node-bindings"] }
 csv = { workspace = true }
 termcolor = "1.4.1"
+rand.workspace = true

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -51,10 +51,9 @@ Requires --priv-key to be set for each 'from' address in the given testfile.",
         #[arg(
             short,
             long,
-            long_help = "The seed to use for generating spam transactions",
-            default_value = "0xffffffffffffffffffffffffffffffff13131313131313131313131313131313"
+            long_help = "The seed to use for generating spam transactions"
         )]
-        seed: String,
+        seed: Option<String>,
 
         /// The private keys to use for blockwise spamming.
         /// Required if `txs_per_block` is set.
@@ -112,13 +111,8 @@ May be specified multiple times."
         min_balance: String,
 
         /// The seed used to generate pool accounts.
-        #[arg(
-            short,
-            long,
-            long_help = "The seed used to generate pool accounts.",
-            default_value = "0xffffffffffffffffffffffffffffffff13131313131313131313131313131313"
-        )]
-        seed: String,
+        #[arg(short, long, long_help = "The seed used to generate pool accounts.")]
+        seed: Option<String>,
 
         /// The number of signers to generate for each pool.
         #[arg(


### PR DESCRIPTION
## Motivation

https://github.com/flashbots/contender/issues/77

## Solution

- load/create `~/.contender/seed` at runtime in CLI
- use it as default, but still allow custom seed to be passed as before

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes