### PR TITLE
add -r flag to spam; runs report and saves to filename passed by -r

### DIFF
--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -80,6 +80,16 @@ May be specified multiple times."
             default_value = "1.0"
         )]
         min_balance: String,
+
+        /// The path to save the report to.
+        /// If not provided, the report can be generated with the `report` subcommand.
+        /// If provided, the report is saved to the given path.
+        #[arg(
+            short,
+            long,
+            long_help = "Filename of the saved report. May be a fully-qualified path. If not provided, the report can be generated with the `report` subcommand. '.csv' extension is added automatically."
+        )]
+        report_file: Option<String>,
     },
 
     #[command(

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -24,10 +24,12 @@ pub fn report(
     };
     let txs = db.get_run_txs(id)?;
     println!("found {} txs", txs.len());
-    println!(
-        "Exporting report for run ID {:?} to out_file {:?}",
-        id, out_file
-    );
+    if let Some(out_file) = &out_file {
+        println!(
+            "Exporting report for run ID {:?} to out_file {:?}",
+            id, out_file
+        );
+    }
 
     if let Some(out_file) = out_file {
         let mut writer = WriterBuilder::new().has_headers(true).from_path(out_file)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -81,9 +81,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             private_keys,
             disable_reports,
             min_balance,
+            report_file,
         } => {
             let seed = seed.unwrap_or(stored_seed);
-            commands::spam(
+            let run_id = commands::spam(
                 &db,
                 SpamCommandArgs {
                     testfile,
@@ -98,7 +99,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     min_balance,
                 },
             )
-            .await?
+            .await?;
+            if report_file.is_some() {
+                commands::report(
+                    &db,
+                    Some(run_id),
+                    report_file.map(|rf| format!("{}.csv", rf)),
+                )?;
+            }
         }
 
         ContenderSubcommand::Report { id, out_file } => commands::report(&db, id, out_file)?,


### PR DESCRIPTION
## Motivation

https://github.com/flashbots/contender/issues/42

## Solution

- add `-r` flag to `spam` command
- run `report` from `spam` if `-r` is passed, use filename given by `-r` to write report

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes