### PR TITLE
check funder balance is sufficient to fund all accounts before funding any

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -364,7 +364,7 @@ mod test {
         }
 
         let res = fund_accounts(
-            &vec!["0x0000000000000000000000000000000000000014"
+            &["0x0000000000000000000000000000000000000014"
                 .parse::<Address>()
                 .unwrap()],
             &new_signer,


### PR DESCRIPTION
## Motivation

- https://github.com/flashbots/contender/issues/89
- https://github.com/flashbots/contender/issues/87

Users were seeing low-level error messages during the funding step which didn't explain the high-level problem. This change stops you before that can happen.

## Solution

- sum up total cost of funding accounts in `fund_accounts` and error if the sender has less than that balance
  - takes into account gas price and adds 10% in case of future congestion
- shorten log to make it not seem like an error

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes