### PR TITLE
add post-setup log

### DIFF
--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -121,7 +121,9 @@ pub async fn setup(
     .await?;
 
     scenario.deploy_contracts().await?;
+    println!("Finished deploying contracts. Running setup txs...");
     scenario.run_setup().await?;
+    println!("Setup complete. To run the scenario, use the `spam` command.");
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

https://github.com/flashbots/contender/issues/86

## Solution

- print more logs at end of setup
