### PR TITLE
check spam cost before funding or spamming

### DIFF
--- a/crates/bundle_provider/src/bundle_provider.rs
+++ b/crates/bundle_provider/src/bundle_provider.rs
@@ -3,6 +3,7 @@ use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::{core::client::ClientT, rpc_params};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug)]
 pub struct BundleClient {
     client: HttpClient,
 }

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -116,7 +116,8 @@ pub async fn spam(
     )
     .await?;
 
-    let total_cost = get_max_spam_cost(scenario.to_owned(), &rpc_client, duration).await?;
+    let total_cost =
+        get_max_spam_cost(scenario.to_owned(), &rpc_client).await? * U256::from(duration);
     if min_balance < U256::from(total_cost) {
         return Err(ContenderError::SpamError(
             "min_balance is not enough to cover the cost of the spam transactions",
@@ -196,7 +197,7 @@ pub async fn spam(
     Ok(run_id)
 }
 
-/// Returns the maximum total cost of spam transactions for one account.
+/// Returns the maximum cost of a spam transaction.
 ///
 /// We take `scenario` by value rather than by reference, because we call `prepare_tx_request`
 /// and `prepare_spam` which will mutate the scenario (namely the overly-optimistic internal nonce counter).
@@ -205,7 +206,6 @@ pub async fn spam(
 async fn get_max_spam_cost<D: DbOps + Send + Sync + 'static, S: Seeder + Send + Sync>(
     scenario: TestScenario<D, S, TestConfig>,
     rpc_client: &AnyProvider,
-    duration: usize,
 ) -> Result<U256, Box<dyn std::error::Error>> {
     let mut scenario = scenario;
 
@@ -271,6 +271,5 @@ async fn get_max_spam_cost<D: DbOps + Send + Sync + 'static, S: Seeder + Send + 
         ))?;
 
     // we assume the highest possible cost to minimize the chances of running out of ETH mid-test
-    let total_cost = highest_gas_cost * U256::from(duration);
-    Ok(total_cost)
+    Ok(highest_gas_cost)
 }

--- a/crates/core/src/agent_controller.rs
+++ b/crates/core/src/agent_controller.rs
@@ -19,12 +19,12 @@ pub trait AgentRegistry<Index: Ord> {
     fn get_agent(&self, idx: Index) -> Option<&Address>;
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SignerStore {
     pub signers: Vec<PrivateKeySigner>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AgentStore {
     agents: HashMap<String, SignerStore>,
 }

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -33,7 +33,7 @@ where
     rpc: Arc<AnyProvider>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PendingRunTx {
     tx_hash: TxHash,
     start_timestamp: usize,
@@ -191,6 +191,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct TxActorHandle {
     sender: mpsc::Sender<TxActorMessage>,
 }

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// A test scenario can be used to run a test with a specific configuration, database, and RPC provider.
+#[derive(Clone, Debug)]
 pub struct TestScenario<D, S, P>
 where
     D: DbOps + Send + Sync + 'static,

--- a/scenarios/mempool.toml
+++ b/scenarios/mempool.toml
@@ -9,8 +9,8 @@ from_pool = "admin"
 to = "{SpamMe2}"
 from_pool = "redpool"
 signature = "consumeGas(uint256 gasAmount)"
-args = ["910000"]
-fuzz = [{ param = "gasAmount", min = "10000000", max = "30000000" }]
+args = ["3000000"]
+fuzz = [{ param = "gasAmount", min = "1000000", max = "3000000" }]
 
 [[spam]]
 
@@ -18,4 +18,4 @@ fuzz = [{ param = "gasAmount", min = "10000000", max = "30000000" }]
 to = "{SpamMe2}"
 from_pool = "bluepool"
 signature = "consumeGas(uint256 gasAmount)"
-args = ["13500000"]
+args = ["1350000"]


### PR DESCRIPTION
## Motivation

https://github.com/flashbots/contender/issues/98

## Solution

Added a new function `get_max_spam_cost`, which generates a sample selection of spam txs (fetching `gasLimit` and `gasPrice`) and returns the cost of the highest-costing transaction. Then we multiply that value by `duration` in the spammer to get the max ETH needed to fund a spammer agent.

Checking this value against `min_balance` in the spammer will ensure that the user provides enough ETH to each account to prevent any `insufficient funds` errors from cropping up mid-run.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes