### PR TITLE
fix: placeholder logic for > 2 placeholders

### DIFF
--- a/crates/core/src/generator/templater.rs
+++ b/crates/core/src/generator/templater.rs
@@ -39,13 +39,14 @@ where
 
         for _ in 0..num_template_vals {
             let template_value = self.copy_end(arg, last_end);
+
             let (template_key, template_end) =
                 self.find_key(&template_value)
                     .ok_or(ContenderError::SpamError(
                         "failed to find placeholder key",
                         Some(arg.to_string()),
                     ))?;
-            last_end = template_end + 1;
+            last_end += template_end + 1;
 
             // skip if value in map, else look up in DB
             if placeholder_map.contains_key(&template_key) {

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -494,11 +494,17 @@ pub mod tests {
         let test_config = TestConfig::default();
 
         let mut placeholder_map = HashMap::new();
-        test_config.find_placeholder_values("{lol}{baa}{hahaa}",  &mut placeholder_map, &MockDb, "http://localhost:8545").unwrap();
+        test_config
+            .find_placeholder_values(
+                "{lol}{baa}{hahaa}",
+                &mut placeholder_map,
+                &MockDb,
+                "http://localhost:8545",
+            )
+            .unwrap();
 
         println!("{:#?}", placeholder_map);
 
         assert_eq!(placeholder_map.len(), 3);
     }
-
 }

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -503,8 +503,6 @@ pub mod tests {
             )
             .unwrap();
 
-        println!("{:#?}", placeholder_map);
-
         assert_eq!(placeholder_map.len(), 3);
     }
 }

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -476,4 +476,29 @@ pub mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_placeholders_count() {
+        use crate::{types::TestConfig, Templater};
+        let test_config = TestConfig::default();
+
+        let count = test_config.num_placeholders("{lol}{baa}{hahaa}");
+
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_placeholders_find() {
+        use crate::{types::TestConfig, Templater};
+
+        let test_config = TestConfig::default();
+
+        let mut placeholder_map = HashMap::new();
+        test_config.find_placeholder_values("{lol}{baa}{hahaa}",  &mut placeholder_map, &MockDb, "http://localhost:8545").unwrap();
+
+        println!("{:#?}", placeholder_map);
+
+        assert_eq!(placeholder_map.len(), 3);
+    }
+
 }

--- a/crates/testfile/src/types.rs
+++ b/crates/testfile/src/types.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 /// Configuration to run a test scenario; used to generate PlanConfigs.
 /// Defines TOML schema for scenario files.
-#[derive(Clone, Deserialize, Debug, Serialize)]
+#[derive(Clone, Deserialize, Debug, Serialize, Default)]
 pub struct TestConfig {
     /// Template variables
     pub env: Option<HashMap<String, String>>,


### PR DESCRIPTION
## Motivation

Templating logic for finding placeholders fails with more than 2 placeholders in an arg, as the arg is not mutated, and the parsers starting point is not accumulating.

## Solution

Accumulate last_end in the loop.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes