### PR TITLE
feat: add EIP-4844 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "alloy",
  "alloy-serde 0.5.4",
  "async-trait",
+ "clap",
  "contender_bundle_provider",
  "futures",
  "rand",

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -1,4 +1,5 @@
 use clap::Subcommand;
+use contender_core::generator::types::TxType;
 
 use crate::default_scenarios::BuiltinScenario;
 
@@ -186,6 +187,10 @@ May be specified multiple times."
             default_value = "100"
         )]
         txs_per_duration: usize,
+
+        /// The type of transaction to spam with.
+        #[arg(long, value_enum, default_value_t = TxType::Eip1559)]
+        tx_type: TxType,
         // TODO: DRY duplicate args
     },
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -11,7 +11,7 @@ use contender_core::{
     agent_controller::AgentStore,
     db::DbOps,
     error::ContenderError,
-    generator::RandSeed,
+    generator::{types::TxType, RandSeed},
     spammer::{LogCallback, Spammer, TimedSpammer},
     test_scenario::TestScenario,
 };
@@ -22,6 +22,7 @@ use crate::{
     util::{check_private_keys, get_signers_with_defaults, prompt_cli},
 };
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     db: &(impl DbOps + Clone + Send + Sync + 'static),
     scenario: BuiltinScenario,
@@ -30,6 +31,7 @@ pub async fn run(
     interval: usize,
     duration: usize,
     txs_per_duration: usize,
+    tx_type: TxType,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let user_signers = get_signers_with_defaults(private_key.map(|s| vec![s]));
     let admin_signer = &user_signers[0];
@@ -56,6 +58,7 @@ pub async fn run(
             txs_per_duration as u64,
             admin_signer.address(),
             fill_percent,
+            tx_type,
         ),
     };
     let testconfig: TestConfig = scenario_config.into();

--- a/crates/cli/src/default_scenarios/runconfig.rs
+++ b/crates/cli/src/default_scenarios/runconfig.rs
@@ -1,5 +1,7 @@
 use alloy::primitives::Address;
-use contender_core::generator::types::{CreateDefinition, FunctionCallDefinition, SpamRequest};
+use contender_core::generator::types::{
+    CreateDefinition, FunctionCallDefinition, SpamRequest, TxType,
+};
 use contender_testfile::TestConfig;
 use serde::{Deserialize, Serialize};
 
@@ -16,6 +18,7 @@ pub enum BuiltinScenarioConfig {
         num_txs: u64,
         sender: Address,
         fill_percent: u16,
+        tx_type: TxType,
     },
 }
 
@@ -25,12 +28,14 @@ impl BuiltinScenarioConfig {
         num_txs: u64,
         sender: Address,
         fill_percent: u16,
+        tx_type: TxType,
     ) -> Self {
         Self::FillBlock {
             max_gas_per_block,
             num_txs,
             sender,
             fill_percent,
+            tx_type,
         }
     }
 }
@@ -43,6 +48,7 @@ impl From<BuiltinScenarioConfig> for TestConfig {
                 num_txs,
                 sender,
                 fill_percent,
+                tx_type,
             } => {
                 let gas_per_tx =
                     ((max_gas_per_block / num_txs as u128) / 100) * fill_percent as u128;
@@ -61,6 +67,7 @@ impl From<BuiltinScenarioConfig> for TestConfig {
                             value: None,
                             fuzz: None,
                             kind: Some("fill-block".to_owned()),
+                            tx_type: Some(tx_type),
                         })
                     })
                     .collect::<Vec<_>>();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -116,6 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             interval,
             duration,
             txs_per_duration,
+            tx_type,
         } => {
             commands::run(
                 &db,
@@ -125,6 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 interval,
                 duration,
                 txs_per_duration,
+                tx_type,
             )
             .await?
         }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,3 +19,4 @@ tokio = { workspace = true, features = ["signal"]}
 alloy-serde = { workspace = true }
 serde_json = { workspace = true }
 contender_bundle_provider = { workspace = true }
+clap = { workspace = true, features = ["derive"] }

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -18,7 +18,7 @@ use named_txs::ExecutionRequest;
 pub use named_txs::NamedTxRequestBuilder;
 pub use seeder::rand_seed::RandSeed;
 use std::{collections::HashMap, fmt::Debug, hash::Hash};
-use types::{CreateDefinitionStrict, FunctionCallDefinitionStrict, SpamRequest};
+use types::{CreateDefinitionStrict, FunctionCallDefinitionStrict, SpamRequest, TxType};
 
 pub use types::{CallbackResult, NamedTxRequest, PlanType};
 
@@ -220,6 +220,8 @@ where
             funcdef.to.to_owned()
         };
 
+        let tx_type = funcdef.tx_type.unwrap_or(TxType::Eip1559);
+
         Ok(FunctionCallDefinitionStrict {
             to: to_address,
             from: from_address,
@@ -228,6 +230,7 @@ where
             value: funcdef.value.to_owned(),
             fuzz: funcdef.fuzz.to_owned().unwrap_or_default(),
             kind: funcdef.kind.to_owned(),
+            tx_type,
         })
     }
 

--- a/crates/core/src/generator/types.rs
+++ b/crates/core/src/generator/types.rs
@@ -116,7 +116,7 @@ pub enum PlanType<F: Fn(NamedTxRequest) -> CallbackResult> {
     Spam(usize, F),
 }
 
-/// The type of a tx.
+/// The type of a transaction.
 #[derive(Copy, Clone, Debug, PartialEq, clap::ValueEnum, Serialize, Deserialize)]
 pub enum TxType {
     /// EIP-1559 transaction.

--- a/crates/core/src/generator/types.rs
+++ b/crates/core/src/generator/types.rs
@@ -37,6 +37,8 @@ pub struct FunctionCallDefinition {
     pub fuzz: Option<Vec<FuzzParam>>,
     /// Optional type of the spam transaction for categorization.
     pub kind: Option<String>,
+    /// The type of transaction.
+    pub tx_type: Option<TxType>,
 }
 
 pub struct FunctionCallDefinitionStrict {
@@ -47,6 +49,8 @@ pub struct FunctionCallDefinitionStrict {
     pub value: Option<String>,
     pub fuzz: Vec<FuzzParam>,
     pub kind: Option<String>,
+    /// The type of transaction.
+    pub tx_type: TxType,
 }
 
 /// User-facing definition of a function call to be executed.
@@ -110,4 +114,13 @@ pub enum PlanType<F: Fn(NamedTxRequest) -> CallbackResult> {
     Create(F),
     Setup(F),
     Spam(usize, F),
+}
+
+/// The type of a tx.
+#[derive(Copy, Clone, Debug, PartialEq, clap::ValueEnum, Serialize, Deserialize)]
+pub enum TxType {
+    /// EIP-1559 transaction.
+    Eip1559,
+    /// EIP-4844 transaction. A blob transaction.
+    Eip4844,
 }

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -352,16 +352,17 @@ where
             ))?
             .to_owned();
 
-        let full_tx = tx_req
+        let mut full_tx = tx_req
             .to_owned()
             .with_nonce(nonce)
             .with_max_fee_per_gas(gas_price + (gas_price / 5))
             .with_max_priority_fee_per_gas(gas_price)
             .with_chain_id(self.chain_id)
-            .with_gas_limit(gas_limit)
-            .with_max_fee_per_blob_gas(gas_price);
+            .with_gas_limit(gas_limit);
 
-        // TODO: max fee per blob gas?
+        if full_tx.blob_sidecar().is_some() {
+            full_tx.set_max_fee_per_blob_gas(gas_price);
+        }
 
         Ok((full_tx, signer))
     }

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -12,7 +12,7 @@ use crate::Result;
 use alloy::consensus::Transaction;
 use alloy::eips::eip2718::Encodable2718;
 use alloy::hex::ToHexExt;
-use alloy::network::{AnyNetwork, EthereumWallet, TransactionBuilder};
+use alloy::network::{AnyNetwork, EthereumWallet, TransactionBuilder, TransactionBuilder4844};
 use alloy::primitives::{keccak256, Address, FixedBytes};
 use alloy::providers::{PendingTransactionConfig, Provider, ProviderBuilder};
 use alloy::rpc::types::TransactionRequest;
@@ -351,13 +351,17 @@ where
                 None,
             ))?
             .to_owned();
+
         let full_tx = tx_req
             .to_owned()
             .with_nonce(nonce)
             .with_max_fee_per_gas(gas_price + (gas_price / 5))
             .with_max_priority_fee_per_gas(gas_price)
             .with_chain_id(self.chain_id)
-            .with_gas_limit(gas_limit);
+            .with_gas_limit(gas_limit)
+            .with_max_fee_per_blob_gas(gas_price);
+
+        // TODO: max fee per blob gas?
 
         Ok((full_tx, signer))
     }
@@ -703,6 +707,7 @@ pub mod tests {
                     .into(),
                     fuzz: None,
                     kind: None,
+                    tx_type: None,
                 },
                 FunctionCallDefinition {
                     to: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D".to_owned(),
@@ -719,6 +724,7 @@ pub mod tests {
                     .into(),
                     fuzz: None,
                     kind: None,
+                    tx_type: None,
                 },
                 FunctionCallDefinition {
                     to: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D".to_owned(),
@@ -729,6 +735,7 @@ pub mod tests {
                     args: vec![].into(),
                     fuzz: None,
                     kind: None,
+                    tx_type: None,
                 },
             ])
         }
@@ -757,6 +764,7 @@ pub mod tests {
                     }]
                     .into(),
                     kind: None,
+                    tx_type: None,
                 })
             };
             Ok(vec![
@@ -785,6 +793,7 @@ pub mod tests {
                     }]
                     .into(),
                     kind: None,
+                    tx_type: None,
                 }),
                 SpamRequest::Tx(FunctionCallDefinition {
                     to: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D".to_owned(),
@@ -808,6 +817,7 @@ pub mod tests {
                     }]
                     .into(),
                     kind: None,
+                    tx_type: None,
                 }),
             ])
         }

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -158,6 +158,7 @@ pub mod tests {
             fuzz: None,
             value: None,
             kind: None,
+            tx_type: None,
         };
 
         TestConfig {
@@ -190,6 +191,7 @@ pub mod tests {
                 max: None,
             }]
             .into(),
+            tx_type: None,
         };
         TestConfig {
             env: None,
@@ -243,6 +245,7 @@ pub mod tests {
                     .into(),
                     kind: None,
                     fuzz: None,
+                    tx_type: None,
                 },
                 FunctionCallDefinition {
                     to: "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D".to_owned(),
@@ -261,6 +264,7 @@ pub mod tests {
                     .into(),
                     kind: None,
                     fuzz: None,
+                    tx_type: None,
                 },
             ]
             .into(),


### PR DESCRIPTION
Closes #112 

This PR adds support for eip4844 transactions. eip4844 transactions can be specified with a new `--tx-type` cli argument. By default, it will send eip1559 transactions.

Adding blob transactions doesn't fit cleanly into the current default scenario due to the nonce gap restrictions on eip4844 transactions: eip4844 transactions are only accepted if they're gapless, meaning the previous nonce of the transaction (`tx.nonce -1`) must either be in the pool or match the on chain nonce of the sender. Due to the fact we send a batch of transactions all at once by spawning tokio tasks, we can guarantee they hit the pool in the correct order. 

To get around this you can set `--num-txs 1`. Not sure of a good work around without a bigger refactor.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes