### PR TITLE
report bugfix

### DIFF
--- a/crates/cli/src/commands/report/chart/heatmap.rs
+++ b/crates/cli/src/commands/report/chart/heatmap.rs
@@ -31,16 +31,6 @@ impl HeatMapChart {
                 .block_number
                 .expect("block number not found in receipt");
 
-            let trace_frame = t.trace.to_owned().try_into_default_frame();
-            if let Err(e) = trace_frame {
-                println!("failed to decode frame (default mode): {:?}", e);
-                continue;
-            }
-            let trace_frame = trace_frame.expect("failed to decode frame (default mode)");
-
-            if trace_frame.failed {
-                continue;
-            }
             let trace_frame = t.trace.to_owned().try_into_pre_state_frame();
             if let Err(e) = trace_frame {
                 println!("failed to decode frame (preState mode): {:?}", e);

--- a/crates/cli/src/commands/report/template.html
+++ b/crates/cli/src/commands/report/template.html
@@ -42,6 +42,7 @@
             {{this.0}}
         </h2>
         <img src="{{this.1}}" alt="{{this.0}}">
+        <div style="page-break-after: always;"></div>
     </div>
     {{/each}}
 </body>


### PR DESCRIPTION
## Motivation

default trace was breaking on chain that supports preState trace

## Solution

delete default trace; it wasn't totally necessary anyways

also added page breaks to the html template for the html report generated by `contender report`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes