### PR TITLE
chore(bundle_provider): rewrite BundleClient to use alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
 ]
 
@@ -394,7 +394,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -624,7 +624,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -639,7 +639,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -919,12 +919,6 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_impl"
@@ -1220,9 +1214,6 @@ name = "contender_bundle_provider"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-serde 0.5.4",
- "jsonrpsee",
- "serde",
 ]
 
 [[package]]
@@ -2031,25 +2022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "handlebars"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,7 +2157,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2194,24 +2165,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "hyper-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -2515,20 +2468,6 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
-dependencies = [
- "cesu8",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
-]
-
-[[package]]
-name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
@@ -2563,74 +2502,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.24.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
-dependencies = [
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-types",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.24.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2882f6f8acb9fdaec7cefc4fd607119a9bd709831df7d7672a1d3b644628280"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.24.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3638bc4617f96675973253b3a45006933bde93c2fd8a6170b33c777cc389e5b"
-dependencies = [
- "async-trait",
- "base64",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustls",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.24.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
-dependencies = [
- "http",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3447,7 +3318,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3592,26 +3463,12 @@ version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3628,33 +3485,6 @@ name = "rustls-pki-types"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
-dependencies = [
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "jni 0.19.0",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-roots",
- "winapi",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3748,7 +3578,6 @@ dependencies = [
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
- "num-bigint",
  "security-framework-sys",
 ]
 
@@ -4281,21 +4110,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -4327,7 +4141,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4620,7 +4433,7 @@ dependencies = [
  "block2",
  "core-foundation 0.10.0",
  "home",
- "jni 0.21.1",
+ "jni",
  "log",
  "ndk-context",
  "objc2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -90,7 +90,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "c-kzg",
  "serde",
 ]
@@ -179,7 +179,7 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "c-kzg",
  "derive_more",
  "once_cell",
@@ -194,7 +194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7a18afb0b318616b6b2b0e2e7ac5529d32a966c673b48091c9919e284e6aca"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "serde",
 ]
 
@@ -236,7 +236,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -253,7 +253,7 @@ checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "serde",
 ]
 
@@ -418,7 +418,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "serde",
 ]
 
@@ -429,7 +429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25cb45ad7c0930dd62eecf164d2afe4c3d2dd2c82af85680ad1f118e1e5cb83"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "serde",
 ]
 
@@ -457,7 +457,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "alloy-sol-types",
  "cfg-if",
  "derive_more",
@@ -475,7 +475,7 @@ checksum = "922d92389e5022650c4c60ffd2f9b2467c3f853764f0f74ff16a23106f9017d5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
@@ -488,7 +488,7 @@ checksum = "98db35cd42c90b484377e6bc44d95377a7a38a5ebee996e67754ac0446d542ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -499,17 +499,6 @@ name = "alloy-serde"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028e72eaa9703e4882344983cfe7636ce06d8cce104a78ea62fd19b46659efc4"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -1253,7 +1242,6 @@ name = "contender_core"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-serde 0.5.4",
  "async-trait",
  "contender_bundle_provider",
  "futures",

--- a/crates/bundle_provider/Cargo.toml
+++ b/crates/bundle_provider/Cargo.toml
@@ -10,6 +10,3 @@ repository.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["node-bindings", "rpc-types-mev"] }
-jsonrpsee = { workspace = true, features = ["http-client", "client-core"] }
-serde = { workspace = true, features = ["derive"] }
-alloy-serde = { workspace = true }

--- a/crates/bundle_provider/src/bundle_provider.rs
+++ b/crates/bundle_provider/src/bundle_provider.rs
@@ -1,92 +1,43 @@
-use alloy::primitives::{Bytes, B256};
-use jsonrpsee::http_client::HttpClient;
-use jsonrpsee::{core::client::ClientT, rpc_params};
-use serde::{Deserialize, Serialize};
+use alloy::{
+    network::AnyNetwork,
+    primitives::Bytes,
+    providers::{Provider, ProviderBuilder, RootProvider},
+    rpc::types::mev::{EthBundleHash, EthSendBundle},
+    transports::http::{reqwest::IntoUrl, Client, Http},
+};
 
+/// A helper wrapper around a RPC client that can be used to call `eth_sendBundle`.
 #[derive(Debug)]
 pub struct BundleClient {
-    client: HttpClient,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EthSendBundleResponse {
-    pub bundle_hash: B256,
+    client: RootProvider<Http<Client>, AnyNetwork>,
 }
 
 impl BundleClient {
-    pub fn new(url: impl AsRef<str>) -> Self {
-        let client = HttpClient::builder()
-            .build(url)
-            .expect("failed to connect to RPC provider");
-        Self { client }
+    /// Creates a new [`BundleClient`] with the given URL.
+    pub fn new(url: impl IntoUrl) -> Self {
+        let provider = ProviderBuilder::default().on_http(url.into_url().unwrap());
+        Self { client: provider }
     }
 
+    /// Sends a bundle using `eth_sendBundle`, discarding the response.
     pub async fn send_bundle(&self, bundle: EthSendBundle) -> Result<(), String> {
         // Result contents optional because some endpoints don't return this response
-        let res: Result<Option<EthSendBundleResponse>, _> = self
-            .client
-            .request("eth_sendBundle", rpc_params![bundle])
-            .await;
-        if let Err(e) = res {
-            return Err(format!("Failed to send bundle: {:?}", e));
-        }
+        self.client
+            .raw_request::<EthSendBundle, Option<EthBundleHash>>("eth_sendBundle".into(), bundle)
+            .await
+            .map_err(|e| format!("Failed to send bundle: {:?}", e))?;
 
         Ok(())
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EthSendBundle {
-    /// A list of hex-encoded signed transactions
-    pub txs: Vec<Bytes>,
-    /// hex-encoded block number for which this bundle is valid
-    #[serde(with = "alloy_serde::quantity")]
-    pub block_number: u64,
-    /// unix timestamp when this bundle becomes active
-    #[serde(
-        default,
-        with = "alloy_serde::quantity::opt",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub min_timestamp: Option<u64>,
-    /// unix timestamp how long this bundle stays valid
-    #[serde(
-        default,
-        with = "alloy_serde::quantity::opt",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub max_timestamp: Option<u64>,
-    /// list of hashes of possibly reverting txs
-    #[serde(
-        default
-        // this doesn't work on rbuilder:
-        // , skip_serializing_if = "Vec::is_empty"
-    )]
-    pub reverting_tx_hashes: Vec<B256>,
-    /// UUID that can be used to cancel/replace this bundle
-    #[serde(
-        default,
-        rename = "replacementUuid",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub replacement_uuid: Option<String>,
-}
-
-impl EthSendBundle {
-    pub fn new_basic(txs: Vec<Bytes>, block_number: u64) -> Self {
-        Self {
-            txs,
-            block_number,
-            min_timestamp: None,
-            max_timestamp: None,
-            reverting_tx_hashes: Vec::new(),
-            replacement_uuid: None,
-        }
-    }
-
-    pub async fn send_to_builder(&self, client: &BundleClient) -> Result<(), String> {
-        client.send_bundle(self.clone()).await
+/// Creates a new bundle with the given transactions and block number, setting the rest of the
+/// fields to default values.
+#[inline]
+pub fn new_basic_bundle(txs: Vec<Bytes>, block_number: u64) -> EthSendBundle {
+    EthSendBundle {
+        txs,
+        block_number,
+        ..Default::default()
     }
 }

--- a/crates/bundle_provider/src/lib.rs
+++ b/crates/bundle_provider/src/lib.rs
@@ -1,3 +1,2 @@
 pub mod bundle_provider;
-
-pub use bundle_provider::{BundleClient, EthSendBundle, EthSendBundleResponse};
+pub use bundle_provider::BundleClient;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,5 @@ serde = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["signal"]}
-alloy-serde = { workspace = true }
 serde_json = { workspace = true }
 contender_bundle_provider = { workspace = true }

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -18,7 +18,8 @@ use alloy::providers::{PendingTransactionConfig, Provider, ProviderBuilder};
 use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::transports::http::reqwest::Url;
-use contender_bundle_provider::{BundleClient, EthSendBundle};
+use contender_bundle_provider::bundle_provider::new_basic_bundle;
+use contender_bundle_provider::BundleClient;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -506,7 +507,7 @@ where
                                 .await
                                 .expect("failed to get block number"),
                         };
-                        let rpc_bundle = EthSendBundle::new_basic(
+                        let rpc_bundle = new_basic_bundle(
                             bundle_txs.into_iter().map(|b| b.into()).collect(),
                             block_num,
                         );
@@ -516,7 +517,7 @@ where
                                 let mut rpc_bundle = rpc_bundle.clone();
                                 rpc_bundle.block_number = block_num + i as u64;
 
-                                let res = rpc_bundle.send_to_builder(&bundle_client).await;
+                                let res = bundle_client.send_bundle(rpc_bundle).await;
                                 if let Err(e) = res {
                                     eprintln!("failed to send bundle: {:?}", e);
                                 }


### PR DESCRIPTION
## Motivation

Most of the code in `bundle_provider` is in alloy and can be removed

## Solution

Replace the duplicated `EthSendBundle` and bundle hash wrapper, also use alloy providers. Improves err handling style using `map_err`. Introduces a basic constructor for `EthSendBundle` that uses `..Default::default()` and does not require foreign impls on the alloy type

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes