### PR TITLE
spam bugfixes

### DIFF
--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -98,7 +98,7 @@ pub async fn spam(
     ]
     .concat();
 
-    if signers_per_period < agents.all_agents().collect::<Vec<_>>().len() {
+    if signers_per_period < all_agents.len() {
         return Err(ContenderError::SpamError(
             "Not enough signers to cover all spam pools. Set --tps or --tpb to a higher value.",
             format!(

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -102,6 +102,15 @@ pub async fn spam(
         panic!("Must set either --txs-per-block (--tpb) or --txs-per-second (--tps)");
     }
 
+    fund_accounts(
+        &all_signer_addrs,
+        &user_signers[0],
+        &rpc_client,
+        &eth_client,
+        min_balance,
+    )
+    .await?;
+
     let mut run_id = 0;
 
     let mut scenario = TestScenario::new(
@@ -130,15 +139,6 @@ pub async fn spam(
         )
         .into());
     }
-
-    fund_accounts(
-        &all_signer_addrs,
-        &user_signers[0],
-        &rpc_client,
-        &eth_client,
-        min_balance,
-    )
-    .await?;
 
     // trigger blockwise spammer
     if let Some(txs_per_block) = args.txs_per_block {

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -60,7 +60,7 @@ pub async fn spam(
         .as_ref()
         .expect("No spam function calls found in testfile");
 
-    if spam.len() == 0 {
+    if spam.is_empty() {
         return Err(ContenderError::SpamError("No spam calls found in testfile", None).into());
     }
 

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -12,7 +12,6 @@ use crate::{
 use alloy::{
     hex::ToHexExt,
     primitives::{Address, U256},
-    rpc::types::serde_helpers::num,
 };
 use async_trait::async_trait;
 use named_txs::ExecutionRequest;

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 use alloy::{
     hex::ToHexExt,
     primitives::{Address, U256},
+    rpc::types::serde_helpers::num,
 };
 use async_trait::async_trait;
 use named_txs::ExecutionRequest;
@@ -361,6 +362,12 @@ where
                     .next()
                     .map(|(_, store)| store.signers.len())
                     .unwrap_or(1);
+                if num_accts == 0 {
+                    return Err(ContenderError::SpamError(
+                        "no accounts found in agent store",
+                        None,
+                    ));
+                }
 
                 // txs will be grouped by step [from=1, from=2, from=3, from=1, from=2, from=3, ...]
                 for step in spam_steps.iter() {


### PR DESCRIPTION
accounts not being funded before the scenario is initialized causes a crash because the TestScenario is trying to estimate gas usage with empty accounts.

- fund accounts before creating scenario
- error early with bad params
