### PR TITLE
bundle provider serialization fix

### DIFF
--- a/crates/bundle_provider/src/bundle_provider.rs
+++ b/crates/bundle_provider/src/bundle_provider.rs
@@ -23,7 +23,7 @@ impl BundleClient {
     pub async fn send_bundle(&self, bundle: EthSendBundle) -> Result<(), String> {
         // Result contents optional because some endpoints don't return this response
         self.client
-            .raw_request::<EthSendBundle, Option<EthBundleHash>>("eth_sendBundle".into(), bundle)
+            .raw_request::<_, Option<EthBundleHash>>("eth_sendBundle".into(), [bundle])
             .await
             .map_err(|e| format!("Failed to send bundle: {:?}", e))?;
 


### PR DESCRIPTION
The lack of parentheses or brackets seemed to affect the JSON here. This was erroring for me. Docs for reference:
https://docs.rs/alloy/0.3.6/alloy/providers/trait.Provider.html#method.raw_request