### PR TITLE
fix ctrl-c handling

### DIFF
--- a/crates/core/src/spammer/spammer_trait.rs
+++ b/crates/core/src/spammer/spammer_trait.rs
@@ -155,7 +155,12 @@ where
                 }
             };
             if !flush_finished {
-                println!("Result collection terminated. Run results may not have been saved to the database.");
+                let runid = if let Some(run_id) = run_id {
+                    format!(" run_id={run_id}")
+                } else {
+                    "".to_string()
+                };
+                println!("Result collection terminated. Some results may not have been saved to the database.{runid}");
             }
 
             Ok(())

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -24,6 +24,9 @@ enum TxActorMessage {
         on_flush: oneshot::Sender<usize>, // returns the number of txs remaining in cache
         target_block_num: u64,
     },
+    Stop {
+        on_stop: oneshot::Sender<()>,
+    },
 }
 
 struct TxActor<D>
@@ -70,11 +73,111 @@ where
         }
     }
 
+    async fn flush_cache(
+        cache: &mut Vec<PendingRunTx>,
+        db: &Arc<D>,
+        rpc: &Arc<AnyProvider>,
+        run_id: u64,
+        on_flush: oneshot::Sender<usize>, // returns the number of txs remaining in cache
+        target_block_num: u64,
+    ) -> Result<Vec<PendingRunTx>, Box<dyn std::error::Error>> {
+        println!("unconfirmed txs: {}", cache.len());
+        let mut maybe_block;
+        loop {
+            maybe_block = rpc
+                .get_block_by_number(target_block_num.into(), BlockTransactionsKind::Hashes)
+                .await;
+            if let Ok(maybe_block) = &maybe_block {
+                if maybe_block.is_some() {
+                    break;
+                }
+            }
+            println!("waiting for block {}", target_block_num);
+            std::thread::sleep(Duration::from_secs(1));
+        }
+        let target_block = maybe_block
+            .expect("this should never happen")
+            .expect("this should never happen");
+        let receipts = rpc
+            .get_block_receipts(target_block_num.into())
+            .await?
+            .unwrap_or_default();
+        println!(
+            "found {} receipts for block {}",
+            receipts.len(),
+            target_block_num
+        );
+        // filter for txs that were included in the block
+        let receipt_tx_hashes = receipts
+            .iter()
+            .map(|r| r.transaction_hash)
+            .collect::<Vec<_>>();
+        let confirmed_txs = cache
+            .iter()
+            .filter(|tx| receipt_tx_hashes.contains(&tx.tx_hash))
+            .map(|tx| tx.to_owned())
+            .collect::<Vec<_>>();
+
+        // refill cache with any txs that were not included in pending_txs
+        let new_txs = cache
+            .iter()
+            .filter(|tx| !confirmed_txs.contains(tx))
+            .map(|tx| tx.to_owned())
+            .collect::<Vec<_>>();
+        *cache = new_txs.to_vec();
+
+        // ready to go to the DB
+        let run_txs = confirmed_txs
+            .into_iter()
+            .map(|pending_tx| {
+                let receipt = receipts
+                    .iter()
+                    .find(|r| r.transaction_hash == pending_tx.tx_hash)
+                    .expect("this should never happen");
+                if !receipt.status() {
+                    println!("tx failed: {:?}", pending_tx.tx_hash);
+                } else {
+                    println!(
+                        "tx landed. hash={}\tgas_used={}\tblock_num={}",
+                        pending_tx.tx_hash,
+                        receipt.gas_used,
+                        receipt
+                            .block_number
+                            .map(|n| n.to_string())
+                            .unwrap_or("N/A".to_owned())
+                    );
+                }
+                RunTx {
+                    tx_hash: pending_tx.tx_hash,
+                    start_timestamp: pending_tx.start_timestamp / 1000,
+                    end_timestamp: target_block.header.timestamp as usize,
+                    block_number: target_block.header.number,
+                    gas_used: receipt.gas_used,
+                    kind: pending_tx.kind,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        db.insert_run_txs(run_id, run_txs)?;
+        on_flush
+            .send(new_txs.len())
+            .map_err(|_| ContenderError::SpamError("failed to join TxActor on_flush", None))?;
+        Ok(new_txs)
+    }
+
     async fn handle_message(
-        &mut self,
+        cache: &mut Vec<PendingRunTx>,
+        db: &Arc<D>,
+        rpc: &Arc<AnyProvider>,
         message: TxActorMessage,
     ) -> Result<(), Box<dyn std::error::Error>> {
         match message {
+            TxActorMessage::Stop { on_stop } => {
+                on_stop.send(()).map_err(|_| {
+                    ContenderError::SpamError("failed to join TxActor on_stop", None)
+                })?;
+                return Ok(());
+            }
             TxActorMessage::SentRunTx {
                 tx_hash,
                 start_timestamp,
@@ -86,7 +189,7 @@ where
                     start_timestamp,
                     kind,
                 };
-                self.cache.push(run_tx.to_owned());
+                cache.push(run_tx.to_owned());
                 on_receipt.send(()).map_err(|_| {
                     ContenderError::SpamError("failed to join TxActor callback", None)
                 })?;
@@ -96,91 +199,7 @@ where
                 run_id,
                 target_block_num,
             } => {
-                println!("unconfirmed txs: {}", self.cache.len());
-                let mut maybe_block;
-                loop {
-                    maybe_block = self
-                        .rpc
-                        .get_block_by_number(target_block_num.into(), BlockTransactionsKind::Hashes)
-                        .await;
-                    if let Ok(maybe_block) = &maybe_block {
-                        if maybe_block.is_some() {
-                            break;
-                        }
-                    }
-                    println!("waiting for block {}", target_block_num);
-                    std::thread::sleep(Duration::from_secs(1));
-                }
-                let target_block = maybe_block
-                    .expect("this should never happen")
-                    .expect("this should never happen");
-                let receipts = self
-                    .rpc
-                    .get_block_receipts(target_block_num.into())
-                    .await?
-                    .unwrap_or_default();
-                println!(
-                    "found {} receipts for block {}",
-                    receipts.len(),
-                    target_block_num
-                );
-                // filter for txs that were included in the block
-                let receipt_tx_hashes = receipts
-                    .iter()
-                    .map(|r| r.transaction_hash)
-                    .collect::<Vec<_>>();
-                let confirmed_txs = self
-                    .cache
-                    .iter()
-                    .filter(|tx| receipt_tx_hashes.contains(&tx.tx_hash))
-                    .map(|tx| tx.to_owned())
-                    .collect::<Vec<_>>();
-
-                // refill cache with any txs that were not included in pending_txs
-                let new_txs = &self
-                    .cache
-                    .iter()
-                    .filter(|tx| !confirmed_txs.contains(tx))
-                    .map(|tx| tx.to_owned())
-                    .collect::<Vec<_>>();
-                self.cache = new_txs.to_vec();
-
-                // ready to go to the DB
-                let run_txs = confirmed_txs
-                    .into_iter()
-                    .map(|pending_tx| {
-                        let receipt = receipts
-                            .iter()
-                            .find(|r| r.transaction_hash == pending_tx.tx_hash)
-                            .expect("this should never happen");
-                        if !receipt.status() {
-                            println!("tx failed: {:?}", pending_tx.tx_hash);
-                        } else {
-                            println!(
-                                "tx landed. hash={}\tgas_used={}\tblock_num={}",
-                                pending_tx.tx_hash,
-                                receipt.gas_used,
-                                receipt
-                                    .block_number
-                                    .map(|n| n.to_string())
-                                    .unwrap_or("N/A".to_owned())
-                            );
-                        }
-                        RunTx {
-                            tx_hash: pending_tx.tx_hash,
-                            start_timestamp: pending_tx.start_timestamp / 1000,
-                            end_timestamp: target_block.header.timestamp as usize,
-                            block_number: target_block.header.number,
-                            gas_used: receipt.gas_used,
-                            kind: pending_tx.kind,
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                self.db.insert_run_txs(run_id, run_txs)?;
-                on_flush.send(new_txs.len()).map_err(|_| {
-                    ContenderError::SpamError("failed to join TxActor on_flush", None)
-                })?;
+                Self::flush_cache(cache, db, rpc, run_id, on_flush, target_block_num).await?;
             }
         }
         Ok(())
@@ -188,7 +207,31 @@ where
 
     pub async fn run(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         while let Some(msg) = self.receiver.recv().await {
-            self.handle_message(msg).await?;
+            match &msg {
+                TxActorMessage::FlushCache {
+                    run_id: _,
+                    on_flush: _,
+                    target_block_num: _,
+                } => {
+                    tokio::select! {
+                        _ = Self::handle_message(&mut self.cache, &self.db, &self.rpc,
+                            msg
+                        ) => {},
+                        Some(TxActorMessage::Stop{on_stop: _}) = self.receiver.recv() => {
+                            // exits early if a stop message is received
+                        },
+                    };
+                }
+                TxActorMessage::SentRunTx {
+                    tx_hash: _,
+                    start_timestamp: _,
+                    kind: _,
+                    on_receipt: _,
+                } => {
+                    Self::handle_message(&mut self.cache, &self.db, &self.rpc, msg).await?;
+                }
+                _ => {}
+            }
         }
         Ok(())
     }
@@ -208,7 +251,7 @@ impl TxActorHandle {
         let (sender, receiver) = mpsc::channel(bufsize);
         let mut actor = TxActor::new(receiver, db, rpc);
         tokio::task::spawn(async move {
-            actor.run().await.expect("tx actor crashed");
+            actor.run().await.expect("tx actor massively failed");
         });
         Self { sender }
     }
@@ -244,6 +287,14 @@ impl TxActorHandle {
                 on_flush: sender,
                 target_block_num,
             })
+            .await?;
+        Ok(receiver.await?)
+    }
+
+    pub async fn stop(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send(TxActorMessage::Stop { on_stop: sender })
             .await?;
         Ok(receiver.await?)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://github.com/flashbots/contender/issues/127

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Revamp how interrupts are handled in the spammer. Instead of using an atomic lock, we use `tokio::select!` to handle new signals while waiting for long-running functions to execute.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes