### PR TITLE
Add multi-arch support to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Test
 
 on:
   push:
@@ -11,8 +11,13 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    name: Build on ${{ matrix.configs.runner }}
+    runs-on: ${{ matrix.configs.runner }}
+    strategy:
+      matrix:
+        configs:
+          - runner: warp-ubuntu-latest-x64-32x
+          - runner: warp-ubuntu-latest-arm64-32x
 
     steps:
     - uses: actions/checkout@v4
@@ -26,7 +31,13 @@ jobs:
       run: cargo build --verbose --workspace
 
   test:
-    runs-on: ubuntu-latest
+    name: Test on ${{ matrix.configs.runner }}
+    runs-on: ${{ matrix.configs.runner }}
+    strategy:
+      matrix:
+        configs:
+          - runner: warp-ubuntu-latest-x64-16x
+          - runner: warp-ubuntu-latest-arm64-16x
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow to improve the build and test process. The most important changes include renaming the workflow file, updating the job names, and introducing a matrix strategy for different runner configurations.

Workflow file renaming and updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L1-R1): Renamed from `.github/workflows/rust.yml` and updated the workflow name from "Build and Test" to "Test".

Matrix strategy introduction:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R20): Updated the `build` job to use a matrix strategy with different runner configurations (`warp-ubuntu-latest-x64-32x` and `warp-ubuntu-latest-arm64-32x`).
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L29-R40): Updated the `test` job to use a matrix strategy with different runner configurations (`warp-ubuntu-latest-x64-16x` and `warp-ubuntu-latest-arm64-16x`).