### PR TITLE
Add codeowners for PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+*         @zeroXbrock
+/.github/ @zeroXbrock @sukoneck


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns default ownership of the repository and the `.github` directory to specific team members.

Ownership assignments:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R5): Assigned `@zeroXbrock` as the default owner for everything in the repo, and both `@zeroXbrock` and `@sukoneck` as owners for the `.github` directory.