### PR TITLE
make fund_accounts async

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -2,7 +2,7 @@ use alloy::{
     consensus::TxType,
     hex::ToHexExt,
     network::{EthereumWallet, TransactionBuilder},
-    primitives::{utils::format_ether, Address, FixedBytes, TxHash, U256},
+    primitives::{utils::format_ether, Address, U256},
     providers::{PendingTransactionConfig, Provider},
     rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
@@ -17,7 +17,6 @@ use contender_core::{
 };
 use contender_testfile::TestConfig;
 use csv::Writer;
-use serde::ser::StdError;
 use std::{io::Write, str::FromStr, sync::Arc};
 use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
 

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -146,7 +146,6 @@ pub async fn fund_accounts(
     let insufficient_balances =
         find_insufficient_balances(recipient_addresses, min_balance, rpc_client).await?;
 
-    // let mut pending_fund_txs = vec![];
     let admin_nonce = rpc_client
         .get_transaction_count(fund_with.address())
         .await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We were waiting for each funding tx to land before calling the next, making funding a large number of accounts very time-consuming, despite not consuming much gas.

## Solution

Send fund txs async.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes