### PR TITLE
spamd

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ Pass a private key with `-p` to fund agent accounts from your account:
 contender spam ./scenarios/stress.toml $RPC_URL --tps 10 -d 3 -p $PRV_KEY
 ```
 
+Generate a report immediately following a spam run:
+
+```bash
+contender spam ./scenarios/stress.toml $RPC_URL --tps 10 -d 3 -p $PRV_KEY --gen-report
+```
+
+---
+
+Run spammer indefinitely:
+
+```bash
+contender spamd ./scenarios/stress.toml $RPC_URL --tps 10 -d 3 -p $PRV_KEY
+```
+
+Run spammer for 5 minutes:
+
+```bash
+contender spamd ./scenarios/stress.toml $RPC_URL --tps 10 -d 3 -p $PRV_KEY --tl $((60 * 5))
+```
+
 ---
 
 Generate a chain performance report for the most recent run.

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -1,0 +1,84 @@
+//! This file contains type definition for CLI arguments.
+
+use crate::util::TxTypeCli;
+
+/// Args required to load a scenario and generate txs.
+#[derive(Debug, clap::Args)]
+pub struct ScenarioSendTxsCliArgs {
+    /// The path to the test file to use for spamming.
+    pub testfile: String,
+
+    /// The HTTP JSON-RPC URL to spam with requests.
+    pub rpc_url: String,
+
+    /// The seed to use for generating spam transactions & accounts.
+    #[arg(
+        short,
+        long,
+        long_help = "The seed to use for generating spam transactions"
+    )]
+    pub seed: Option<String>,
+
+    /// The private keys to use for blockwise spamming.
+    /// Required if `txs_per_block` is set.
+    #[arg(
+        short,
+        long = "priv-key",
+        long_help = "Add private keys to wallet map. Used to fund agent accounts or sign transactions.
+May be specified multiple times."
+    )]
+    pub private_keys: Option<Vec<String>>,
+
+    /// The minimum balance to check for each private key.
+    #[arg(
+        long,
+        long_help = "The minimum balance to check for each private key in decimal-ETH format (`--min-balance 1.5` means 1.5 * 1e18 wei).",
+        default_value = "0.01"
+    )]
+    pub min_balance: String,
+
+    /// Transaction type
+    #[arg(
+            short = 't',
+            long,
+            long_help = "Transaction type for generated transactions.",
+            value_enum,
+            default_value_t = TxTypeCli::Eip1559,
+        )]
+    pub tx_type: TxTypeCli,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct SendSpamCliArgs {
+    /// HTTP JSON-RPC URL to use for bundle spamming (must support `eth_sendBundle`).
+    #[arg(
+        short,
+        long,
+        long_help = "HTTP JSON-RPC URL to use for bundle spamming (must support `eth_sendBundle`)"
+    )]
+    pub builder_url: Option<String>,
+
+    /// The number of txs to send per second using the timed spammer. This is the default spammer.
+    /// May not be set if `txs_per_block` is set.
+    #[arg(long, long_help = "Number of txs to send per second. Must not be set if --txs-per-block is set.", visible_aliases = &["tps"])]
+    pub txs_per_second: Option<usize>,
+
+    /// The number of txs to send per block using the blockwise spammer.
+    /// May not be set if `txs_per_second` is set. Requires `prv_keys` to be set.
+    #[arg(
+            long,
+            long_help =
+"Number of txs to send per block. Must not be set if --txs-per-second is set.
+Requires --priv-key to be set for each 'from' address in the given testfile.",
+        visible_aliases = &["tpb"])]
+    pub txs_per_block: Option<usize>,
+
+    /// The duration of the spamming run in seconds or blocks, depending on whether `txs_per_second` or `txs_per_block` is set.
+    #[arg(
+        short,
+        long,
+        default_value = "10",
+        long_help = "Duration of the spamming run in seconds or blocks, depending on whether --txs-per-second or --txs-per-block is set."
+    )]
+    pub duration: Option<usize>,
+}

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -2,7 +2,6 @@
 
 use crate::util::TxTypeCli;
 
-/// Args required to load a scenario and generate txs.
 #[derive(Debug, clap::Args)]
 pub struct ScenarioSendTxsCliArgs {
     /// The path to the test file to use for spamming.

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -24,8 +24,17 @@ pub enum ContenderSubcommand {
     },
 
     #[command(
+        name = "spamd",
+        long_about = "Spam the RPC with tx requests as designated in the given testfile over a long duration."
+    )]
+    SpamD {
+        #[command(flatten)]
+        args: SpamCliArgs,
+    },
+
+    #[command(
         name = "setup",
-        long_about = "Run the setup step(s) in the given testfile."
+        long_about = "Deploy contracts and run the setup step(s) in the given testfile."
     )]
     Setup {
         #[command(flatten)]

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -25,7 +25,7 @@ pub enum ContenderSubcommand {
 
     #[command(
         name = "spamd",
-        long_about = "Spam the RPC with tx requests as designated in the given testfile over a long duration."
+        long_about = "Run spam in a loop over a long duration or indefinitely."
     )]
     SpamD {
         #[command(flatten)]

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -1,11 +1,10 @@
 use clap::Subcommand;
 use std::path::PathBuf;
 
+use super::setup::SetupCliArgs;
+use super::spam::SpamCliArgs;
 use crate::default_scenarios::BuiltinScenario;
 use crate::util::TxTypeCli;
-
-use super::common::ScenarioSendTxsCliArgs;
-use super::spam::SpamCliArgs;
 
 #[derive(Debug, Subcommand)]
 pub enum ContenderSubcommand {
@@ -30,7 +29,7 @@ pub enum ContenderSubcommand {
     )]
     Setup {
         #[command(flatten)]
-        args: ScenarioSendTxsCliArgs,
+        args: SetupCliArgs,
     },
 
     #[command(

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 use crate::default_scenarios::BuiltinScenario;
 use crate::util::TxTypeCli;
 
+use super::common::ScenarioSendTxsCliArgs;
+use super::spam::SpamCliArgs;
+
 #[derive(Debug, Subcommand)]
 pub enum ContenderSubcommand {
     #[command(name = "db", about = "Database management commands")]
@@ -17,105 +20,8 @@ pub enum ContenderSubcommand {
         long_about = "Spam the RPC with tx requests as designated in the given testfile."
     )]
     Spam {
-        /// The path to the test file to use for spamming.
-        testfile: String,
-
-        /// The HTTP JSON-RPC URL to spam with requests.
-        rpc_url: String,
-
-        /// HTTP JSON-RPC URL to use for bundle spamming (must support `eth_sendBundle`).
-        #[arg(
-            short,
-            long,
-            long_help = "HTTP JSON-RPC URL to use for bundle spamming (must support `eth_sendBundle`)"
-        )]
-        builder_url: Option<String>,
-
-        /// The number of txs to send per second using the timed spammer. This is the default spammer.
-        /// May not be set if `txs_per_block` is set.
-        #[arg(long, long_help = "Number of txs to send per second. Must not be set if --txs-per-block is set.", visible_aliases = &["tps"])]
-        txs_per_second: Option<usize>,
-
-        /// The number of txs to send per block using the blockwise spammer.
-        /// May not be set if `txs_per_second` is set. Requires `prv_keys` to be set.
-        #[arg(
-            long,
-            long_help =
-"Number of txs to send per block. Must not be set if --txs-per-second is set.
-Requires --priv-key to be set for each 'from' address in the given testfile.",
-        visible_aliases = &["tpb"])]
-        txs_per_block: Option<usize>,
-
-        /// The duration of the spamming run in seconds or blocks, depending on whether `txs_per_second` or `txs_per_block` is set.
-        #[arg(
-            short,
-            long,
-            default_value = "10",
-            long_help = "Duration of the spamming run in seconds or blocks, depending on whether --txs-per-second or --txs-per-block is set."
-        )]
-        duration: Option<usize>,
-
-        /// The seed to use for generating spam transactions & accounts.
-        #[arg(
-            short,
-            long,
-            long_help = "The seed to use for generating spam transactions"
-        )]
-        seed: Option<String>,
-
-        /// The private keys to use for blockwise spamming.
-        /// Required if `txs_per_block` is set.
-        #[arg(
-            short,
-            long = "priv-key",
-            long_help = "Add private keys for blockwise spamming. Required if --txs-per-block is set.
-May be specified multiple times."
-        )]
-        private_keys: Option<Vec<String>>,
-
-        /// Whether to log reports for the spamming run.
-        #[arg(
-            long,
-            long_help = "Whether to log reports for the spamming run.",
-            visible_aliases = &["dr"]
-        )]
-        disable_reports: bool,
-
-        /// The minimum balance to check for each private key.
-        #[arg(
-            long,
-            long_help = "The minimum balance to check for each private key in decimal-ETH format (`--min-balance 1.5` means 1.5 * 1e18 wei).",
-            default_value = "1.0"
-        )]
-        min_balance: String,
-
-        /// The path to save the report to.
-        /// If not provided, the report can be generated with the `report` subcommand.
-        /// If provided, the report is saved to the given path.
-        #[arg(
-            short = 'r',
-            long,
-            long_help = "Filename of the saved report. May be a fully-qualified path. If not provided, the report can be generated with the `report` subcommand. '.csv' extension is added automatically."
-        )]
-        gen_report: bool,
-
-        /// Adds (gas_price * percent) / 100 to the standard gas price of the transactions.
-        #[arg(
-            short,
-            long,
-            long_help = "Adds given percent increase to the standard gas price of the transactions."
-        )]
-        gas_price_percent_add: Option<u16>,
-
-        /// Transaction type
-        #[arg(
-            short = 't',
-            long,
-            long_help = "Transaction type for spam transactions.",
-            value_enum,
-            default_value_t = TxTypeCli::Eip1559,
-        )]
-        tx_type: TxTypeCli,
+        #[command(flatten)]
+        args: SpamCliArgs,
     },
 
     #[command(
@@ -123,42 +29,8 @@ May be specified multiple times."
         long_about = "Run the setup step(s) in the given testfile."
     )]
     Setup {
-        /// The path to the test file to use for setup.
-        testfile: String,
-
-        /// The HTTP JSON-RPC URL to use for setup.
-        rpc_url: String,
-
-        /// The private keys to use for setup.
-        #[arg(
-            short,
-            long = "priv-key",
-            long_help = "Add private keys used to deploy and setup contracts.
-May be specified multiple times."
-        )]
-        private_keys: Option<Vec<String>>,
-
-        /// The minimum balance to check for each private key.
-        #[arg(
-            long,
-            long_help = "The minimum balance to check for each private key in decimal-ETH format (ex: `--min-balance 1.5` means 1.5 * 1e18 wei).",
-            default_value = "1.0"
-        )]
-        min_balance: String,
-
-        /// The seed used to generate pool accounts.
-        #[arg(short, long, long_help = "The seed used to generate pool accounts.")]
-        seed: Option<String>,
-
-        /// Transaction type
-        #[arg(
-            short = 't',
-            long,
-            long_help = "Transaction type for setup transactions.",
-            value_enum,
-            default_value_t = TxTypeCli::Eip1559,
-        )]
-        tx_type: TxTypeCli,
+        #[command(flatten)]
+        args: ScenarioSendTxsCliArgs,
     },
 
     #[command(

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -29,7 +29,15 @@ pub enum ContenderSubcommand {
     )]
     SpamD {
         #[command(flatten)]
-        args: SpamCliArgs,
+        spam_inner_args: SpamCliArgs,
+
+        #[arg(
+            short = 'l',
+            long,
+            long_help = "The time limit in seconds for the spam daemon. If not provided, the daemon will run indefinitely.",
+            visible_aliases = &["tl"]
+        )]
+        time_limit: Option<u64>,
     },
 
     #[command(

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub use db::*;
 pub use report::report;
 pub use run::{run, RunCommandArgs};
 pub use setup::{setup, SetupCliArgs};
-pub use spam::{spam, SpamCliArgs, SpamCommandArgs};
+pub use spam::{init_spam, spam, InitializedSpammer, SpamCliArgs, SpamCommandArgs};
 pub use spamd::spamd;
 
 #[derive(Parser, Debug)]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,7 +5,6 @@ mod report;
 mod run;
 mod setup;
 mod spam;
-mod spamd;
 
 use clap::Parser;
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod report;
 mod run;
 mod setup;
 mod spam;
+mod spamd;
 
 use clap::Parser;
 
@@ -14,6 +15,7 @@ pub use report::report;
 pub use run::{run, RunCommandArgs};
 pub use setup::{setup, SetupCliArgs};
 pub use spam::{spam, SpamCliArgs, SpamCommandArgs};
+pub use spamd::spamd;
 
 #[derive(Parser, Debug)]
 pub struct ContenderCli {

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,9 +1,11 @@
+pub mod common;
 mod contender_subcommand;
 mod db;
 mod report;
 mod run;
 mod setup;
 mod spam;
+mod spamd;
 
 use clap::Parser;
 
@@ -12,7 +14,7 @@ pub use db::*;
 pub use report::report;
 pub use run::{run, RunCommandArgs};
 pub use setup::setup;
-pub use spam::{spam, SpamCommandArgs};
+pub use spam::{spam, SpamCliArgs, SpamCommandArgs};
 
 #[derive(Parser, Debug)]
 pub struct ContenderCli {

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub use db::*;
 pub use report::report;
 pub use run::{run, RunCommandArgs};
 pub use setup::{setup, SetupCliArgs};
-pub use spam::{init_scenario, spam, InitializedScenario, SpamCliArgs, SpamCommandArgs};
+pub use spam::{spam, InitializedScenario, SpamCliArgs, SpamCommandArgs};
 pub use spamd::spamd;
 
 #[derive(Parser, Debug)]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub use contender_subcommand::{ContenderSubcommand, DbCommand};
 pub use db::*;
 pub use report::report;
 pub use run::{run, RunCommandArgs};
-pub use setup::setup;
+pub use setup::{setup, SetupCliArgs};
 pub use spam::{spam, SpamCliArgs, SpamCommandArgs};
 
 #[derive(Parser, Debug)]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub use db::*;
 pub use report::report;
 pub use run::{run, RunCommandArgs};
 pub use setup::{setup, SetupCliArgs};
-pub use spam::{init_spam, spam, InitializedSpammer, SpamCliArgs, SpamCommandArgs};
+pub use spam::{init_scenario, spam, InitializedScenario, SpamCliArgs, SpamCommandArgs};
 pub use spamd::spamd;
 
 #[derive(Parser, Debug)]

--- a/crates/cli/src/commands/report/block_trace.rs
+++ b/crates/cli/src/commands/report/block_trace.rs
@@ -88,7 +88,7 @@ pub async fn get_block_trace_data(
 
     // get tx traces for all txs in all_blocks
     let mut all_traces = vec![];
-    let (sender, mut receiver) = tokio::sync::mpsc::channel::<TxTraceReceipt>(9001);
+    let (sender, mut receiver) = tokio::sync::mpsc::channel::<TxTraceReceipt>(90001);
 
     for block in &all_blocks {
         let mut tx_tasks = vec![];
@@ -123,7 +123,6 @@ pub async fn get_block_trace_data(
                 if let Ok(receipt) = receipt {
                     if let Some(receipt) = receipt {
                         println!("got receipt for tx {:?}", tx_hash);
-                        // all_traces.push(TxTraceReceipt::new(trace, receipt));
                         sender
                             .send(TxTraceReceipt::new(trace, receipt))
                             .await

--- a/crates/cli/src/commands/report/chart/drawable_charts/gas_per_block.rs
+++ b/crates/cli/src/commands/report/chart/drawable_charts/gas_per_block.rs
@@ -62,7 +62,7 @@ impl DrawableChart for GasPerBlockChart {
             .configure_mesh()
             .disable_x_mesh()
             .x_desc("Block")
-            .x_labels(self.gas_used_per_block.len())
+            .x_labels(20)
             .x_label_formatter(&|block| format!("            {}", block))
             .x_label_style(
                 ("sans-serif", 15)

--- a/crates/cli/src/commands/report/chart/drawable_charts/heatmap.rs
+++ b/crates/cli/src/commands/report/chart/drawable_charts/heatmap.rs
@@ -155,7 +155,7 @@ impl DrawableChart for HeatMapChart {
         chart
             .configure_mesh()
             .x_desc("Block")
-            .x_labels(32)
+            .x_labels(20)
             .x_label_formatter(&|i| {
                 if *i == block_nums.len() {
                     return String::default();

--- a/crates/cli/src/commands/report/chart/drawable_charts/pending_txs.rs
+++ b/crates/cli/src/commands/report/chart/drawable_charts/pending_txs.rs
@@ -90,13 +90,13 @@ impl DrawableChart for PendingTxsChart {
             .configure_mesh()
             .disable_x_mesh()
             .x_desc("Timestamp          ")
-            .x_labels(self.pending_txs_per_second.len())
             .x_label_formatter(&|timestamp| format!("               {}", timestamp))
             .x_label_style(
                 ("sans-serif", 15)
                     .into_text_style(root)
                     .transform(FontTransform::Rotate90),
             )
+            .x_labels(25)
             .y_desc("# Pending Transactions")
             .y_labels(25)
             .y_max_light_lines(1)

--- a/crates/cli/src/commands/report/chart/drawable_charts/time_to_inclusion.rs
+++ b/crates/cli/src/commands/report/chart/drawable_charts/time_to_inclusion.rs
@@ -52,6 +52,7 @@ impl DrawableChart for TimeToInclusionChart {
             .configure_mesh()
             .label_style(("sans-serif", 15))
             .x_label_offset(10)
+            .x_labels(20)
             .x_desc("Time to Inclusion (seconds)")
             .y_desc("# Transactions")
             .draw()?;

--- a/crates/cli/src/commands/report/chart/drawable_charts/tx_gas_used.rs
+++ b/crates/cli/src/commands/report/chart/drawable_charts/tx_gas_used.rs
@@ -51,6 +51,7 @@ impl DrawableChart for TxGasUsedChart {
             .disable_x_mesh()
             .label_style(("sans-serif", 15))
             .x_desc("Gas Used")
+            .x_labels(20)
             .x_label_formatter(&|x| abbreviate_num(*x))
             .y_desc("# Transactions")
             .draw()?;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::{env, str::FromStr};
+use std::{env, str::FromStr, sync::Arc};
 
 use alloy::{
     consensus::TxType,
@@ -121,7 +121,8 @@ pub async fn run(
         args.duration * args.txs_per_duration,
         &format!("{} ({})", contract_name, scenario_name),
     )?;
-    let callback = LogCallback::new(&DynProvider::new(provider.clone()));
+
+    let callback = LogCallback::new(&Arc::new(DynProvider::new(provider)));
 
     println!("starting spammer...");
     spammer

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::{env, str::FromStr, sync::Arc};
+use std::{env, str::FromStr};
 
 use alloy::{
     consensus::TxType,
@@ -121,7 +121,7 @@ pub async fn run(
         args.duration * args.txs_per_duration,
         &format!("{} ({})", contract_name, scenario_name),
     )?;
-    let callback = LogCallback::new(Arc::new(DynProvider::new(provider.clone())));
+    let callback = LogCallback::new(&DynProvider::new(provider.clone()));
 
     println!("starting spammer...");
     spammer

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -15,9 +15,16 @@ use contender_core::{
 use contender_testfile::TestConfig;
 use std::str::FromStr;
 
+use super::common::ScenarioSendTxsCliArgs;
 use crate::util::{
     check_private_keys_fns, find_insufficient_balances, fund_accounts, get_signers_with_defaults,
 };
+
+#[derive(Debug, clap::Args)]
+pub struct SetupCliArgs {
+    #[command(flatten)]
+    pub args: ScenarioSendTxsCliArgs,
+}
 
 pub async fn setup(
     db: &(impl contender_core::db::DbOps + Clone + Send + Sync + 'static),

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -253,13 +253,14 @@ pub async fn spam<
     let duration = duration.unwrap_or_default();
     println!("Duration: {} seconds", duration);
     let mut run_id = None;
+    let rpc_client = Arc::new(rpc_client.to_owned());
 
     // trigger blockwise spammer
     if let Some(txs_per_block) = txs_per_block {
         println!("Blockwise spamming with {} txs per block", txs_per_block);
         let spammer = BlockwiseSpammer {};
 
-        match spam_callback_default(!disable_reporting, Some(&Arc::new(rpc_client))).await {
+        match spam_callback_default(!disable_reporting, Some(&rpc_client)).await {
             SpamCallbackType::Log(cback) => {
                 let timestamp = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -291,7 +292,7 @@ pub async fn spam<
     println!("Timed spamming with {} txs per second", tps);
     let interval = std::time::Duration::from_secs(1);
     let spammer = TimedSpammer::new(interval);
-    match spam_callback_default(!disable_reporting, Some(&Arc::new(rpc_client))).await {
+    match spam_callback_default(!disable_reporting, Some(&rpc_client)).await {
         SpamCallbackType::Log(cback) => {
             let timestamp = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -37,7 +37,7 @@ pub struct SpamCommandArgs {
     pub duration: Option<usize>,
     pub seed: String,
     pub private_keys: Option<Vec<String>>,
-    pub disable_reports: bool,
+    pub disable_reporting: bool,
     pub min_balance: String,
     pub tx_type: TxType,
     pub gas_price_percent_add: Option<u16>,
@@ -54,10 +54,10 @@ pub struct SpamCliArgs {
     /// Whether to log reports for the spamming run.
     #[arg(
             long,
-            long_help = "Whether to log reports for the spamming run.",
+            long_help = "Prevent tx results from being saved to DB.",
             visible_aliases = &["dr"]
         )]
-    pub disable_reports: bool,
+    pub disable_reporting: bool,
 
     /// The path to save the report to.
     /// If not provided, the report can be generated with the `report` subcommand.
@@ -193,7 +193,7 @@ pub async fn spam(
         println!("Blockwise spamming with {} txs per block", txs_per_block);
         let spammer = BlockwiseSpammer {};
 
-        match spam_callback_default(!args.disable_reports, Arc::new(rpc_client).into()).await {
+        match spam_callback_default(!args.disable_reporting, Arc::new(rpc_client).into()).await {
             SpamCallbackType::Log(cback) => {
                 let timestamp = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -225,7 +225,7 @@ pub async fn spam(
     println!("Timed spamming with {} txs per second", tps);
     let interval = std::time::Duration::from_secs(1);
     let spammer = TimedSpammer::new(interval);
-    match spam_callback_default(!args.disable_reports, Arc::new(rpc_client).into()).await {
+    match spam_callback_default(!args.disable_reporting, Arc::new(rpc_client).into()).await {
         SpamCallbackType::Log(cback) => {
             let timestamp = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -47,6 +47,15 @@ pub struct SpamCommandArgs {
     pub gas_price_percent_add: Option<u16>,
 }
 
+impl SpamCommandArgs {
+    pub async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
+        &self,
+        db: &D,
+    ) -> Result<InitializedScenario<D>, Box<dyn std::error::Error>> {
+        init_scenario(db, self).await
+    }
+}
+
 #[derive(Debug, clap::Args)]
 pub struct SpamCliArgs {
     #[command(flatten)]
@@ -93,7 +102,7 @@ where
 }
 
 /// Initializes a TestScenario with the given arguments.
-pub async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
+async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
     db: &D,
     args: &SpamCommandArgs,
 ) -> Result<InitializedScenario<D>, Box<dyn std::error::Error>> {

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -82,7 +82,7 @@ pub struct SpamCliArgs {
     pub gas_price_percent_add: Option<u16>,
 }
 
-pub struct InitializedSpammer<D = SqliteDb, S = RandSeed, P = TestConfig>
+pub struct InitializedScenario<D = SqliteDb, S = RandSeed, P = TestConfig>
 where
     D: DbOps + Clone + Send + Sync + 'static,
     S: Seeder,
@@ -92,10 +92,11 @@ where
     pub rpc_client: AnyProvider,
 }
 
-pub async fn init_spam<D: DbOps + Clone + Send + Sync + 'static>(
+/// Initializes a TestScenario with the given arguments.
+pub async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
     db: &D,
     args: &SpamCommandArgs,
-) -> Result<InitializedSpammer<D>, Box<dyn std::error::Error>> {
+) -> Result<InitializedScenario<D>, Box<dyn std::error::Error>> {
     println!("Initializing spammer...");
     let SpamCommandArgs {
         txs_per_block,
@@ -213,7 +214,7 @@ pub async fn init_spam<D: DbOps + Clone + Send + Sync + 'static>(
         .into());
     }
 
-    Ok(InitializedSpammer {
+    Ok(InitializedScenario {
         scenario,
         rpc_client,
     })

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -227,7 +227,7 @@ pub async fn spam<
     P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
 >(
     db: &D,
-    args: SpamCommandArgs,
+    args: &SpamCommandArgs,
     test_scenario: &mut TestScenario<D, S, P>,
     rpc_client: &AnyProvider,
 ) -> Result<Option<u64>, Box<dyn std::error::Error>> {
@@ -238,7 +238,7 @@ pub async fn spam<
         duration,
         disable_reporting,
         ..
-    } = &args;
+    } = args;
 
     let duration = duration.unwrap_or_default();
     println!("Duration: {} seconds", duration);

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -25,6 +25,8 @@ use crate::util::{
     SpamCallbackType,
 };
 
+use super::common::{ScenarioSendTxsCliArgs, SendSpamCliArgs};
+
 #[derive(Debug)]
 pub struct SpamCommandArgs {
     pub testfile: String,
@@ -38,6 +40,41 @@ pub struct SpamCommandArgs {
     pub disable_reports: bool,
     pub min_balance: String,
     pub tx_type: TxType,
+    pub gas_price_percent_add: Option<u16>,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct SpamCliArgs {
+    #[command(flatten)]
+    pub eth_json_rpc_args: ScenarioSendTxsCliArgs,
+
+    #[command(flatten)]
+    pub spam_args: SendSpamCliArgs,
+
+    /// Whether to log reports for the spamming run.
+    #[arg(
+            long,
+            long_help = "Whether to log reports for the spamming run.",
+            visible_aliases = &["dr"]
+        )]
+    pub disable_reports: bool,
+
+    /// The path to save the report to.
+    /// If not provided, the report can be generated with the `report` subcommand.
+    /// If provided, the report is saved to the given path.
+    #[arg(
+        short = 'r',
+        long,
+        long_help = "Filename of the saved report. May be a fully-qualified path. If not provided, the report can be generated with the `report` subcommand. '.csv' extension is added automatically."
+    )]
+    pub gen_report: bool,
+
+    /// Adds (gas_price * percent) / 100 to the standard gas price of the transactions.
+    #[arg(
+        short,
+        long,
+        long_help = "Adds given percent increase to the standard gas price of the transactions."
+    )]
     pub gas_price_percent_add: Option<u16>,
 }
 

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -1,0 +1,140 @@
+use super::SpamCommandArgs;
+use crate::commands::{self};
+use contender_core::{db::DbOps, error::ContenderError};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+pub async fn spamd(
+    db: &(impl DbOps + Clone + Send + Sync + 'static),
+    args: SpamCommandArgs,
+    gen_report: bool,
+    time_limit: Option<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // collects all run IDs for reporting
+    let (run_id_sender, mut run_id_receiver) = tokio::sync::mpsc::channel::<u64>(1000);
+
+    let SpamCommandArgs {
+        testfile,
+        rpc_url,
+        builder_url,
+        txs_per_block,
+        txs_per_second,
+        duration,
+        seed,
+        private_keys,
+        disable_reporting,
+        min_balance,
+        tx_type,
+        gas_price_percent_add,
+    } = args;
+
+    let finished = Arc::new(AtomicBool::new(false));
+    let start_time = std::time::Instant::now();
+    let rpc = rpc_url.clone();
+
+    // spawn a task to check the time limit and set finished to true if it is reached
+    let is_finished = finished.clone();
+    tokio::task::spawn(async move {
+        // check time limit
+        if let Some(limit) = time_limit {
+            tokio::time::sleep(Duration::from_secs(limit)).await;
+            if start_time.elapsed().as_secs() >= limit {
+                println!("Time limit reached.Spam daemon will shut down as soon as current batch finishes...");
+                is_finished.store(true, Ordering::SeqCst);
+            }
+        }
+    });
+
+    // runs spam command in an async loop; in closure for tokio::select to handle CTRL-C
+    let is_finished = finished.clone();
+    let spam_loop = || async move {
+        loop {
+            if is_finished.load(Ordering::SeqCst) {
+                println!("Spam loop finished");
+                break;
+            }
+            let args = SpamCommandArgs {
+                testfile: testfile.clone(),
+                rpc_url: rpc.to_owned(),
+                builder_url: builder_url.clone(),
+                txs_per_block,
+                txs_per_second,
+                duration: duration.clone(),
+                seed: seed.clone(),
+                private_keys: private_keys.clone(),
+                disable_reporting,
+                min_balance: min_balance.clone(),
+                tx_type: tx_type.into(),
+                gas_price_percent_add,
+            };
+            let db = db.clone();
+            let spam_res = commands::spam(&db, args).await;
+            if let Err(e) = spam_res {
+                println!("spam failed: {:?}", e);
+            } else {
+                println!("spam batch completed");
+                let run_id = spam_res.expect("spam");
+                if let Some(run_id) = run_id {
+                    // run_ids.push(run_id);
+                    run_id_sender
+                        .send(run_id)
+                        .await
+                        .expect("failed to send run ID");
+                }
+            }
+        }
+
+        Ok::<_, ContenderError>(())
+    };
+
+    tokio::select! {
+        _ = spam_loop() => {},
+        _ = tokio::signal::ctrl_c() => {
+            println!("CTRL-C received, stopping spam daemon...");
+        }
+    }
+
+    run_id_receiver.close();
+
+    // generate a report if requested; in closure for tokio::select to handle CTRL-C
+    let run_report = || async move {
+        let mut run_ids = vec![];
+        while let Some(run_id) = run_id_receiver.recv().await {
+            run_ids.push(run_id);
+        }
+
+        if gen_report {
+            if run_ids.is_empty() {
+                println!("No runs found, exiting.");
+                return Ok::<_, ContenderError>(());
+            }
+            let first_run_id = run_ids.iter().min().expect("no run IDs found");
+            let last_run_id = *run_ids.iter().max().expect("no run IDs found");
+            commands::report(
+                Some(last_run_id),
+                last_run_id - first_run_id,
+                &*db,
+                &rpc_url,
+            )
+            .await
+            .map_err(|e| {
+                ContenderError::GenericError("failed to generate report", e.to_string())
+            })?;
+        }
+        Ok(())
+    };
+
+    tokio::select! {
+        _ = run_report() => {},
+        _ = tokio::signal::ctrl_c() => {
+            println!("CTRL-C received, shutting down...");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -1,8 +1,5 @@
 use super::SpamCommandArgs;
-use crate::commands::{
-    self,
-    spam::{init_scenario, InitializedScenario},
-};
+use crate::commands::{self, spam::InitializedScenario};
 use contender_core::{db::DbOps, error::ContenderError};
 use std::{
     sync::{
@@ -38,7 +35,7 @@ pub async fn spamd(
     let InitializedScenario {
         mut scenario,
         rpc_client,
-    } = init_scenario(db, &args).await?;
+    } = args.init_scenario(db).await?;
 
     // collects run IDs from the spam command
     let mut run_ids = vec![];

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -1,7 +1,7 @@
 use super::SpamCommandArgs;
 use crate::commands::{
     self,
-    spam::{init_spam, InitializedSpammer},
+    spam::{init_scenario, InitializedScenario},
 };
 use contender_core::{db::DbOps, error::ContenderError};
 use std::{
@@ -56,10 +56,10 @@ pub async fn spamd(
     // async-safe handle
     let is_finished = finished.clone();
 
-    let InitializedSpammer {
+    let InitializedScenario {
         mut scenario,
         rpc_client,
-    } = init_spam(db, &args).await?;
+    } = init_scenario(db, &args).await?;
 
     // runs spam command in an async loop; in closure for tokio::select to handle CTRL-C
     let spam_loop = || async move {

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -44,7 +44,7 @@ pub async fn spamd(
         if let Some(limit) = time_limit {
             tokio::time::sleep(Duration::from_secs(limit)).await;
             if start_time.elapsed().as_secs() >= limit {
-                println!("Time limit reached.Spam daemon will shut down as soon as current batch finishes...");
+                println!("Time limit reached. Spam daemon will shut down as soon as current batch finishes...");
                 is_finished.store(true, Ordering::SeqCst);
             }
         }

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -19,9 +19,6 @@ pub async fn spamd(
     gen_report: bool,
     time_limit: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // collects all run IDs for reporting
-    let (run_id_sender, mut run_id_receiver) = tokio::sync::mpsc::channel::<u64>(1000);
-
     let SpamCommandArgs {
         testfile,
         rpc_url,
@@ -54,71 +51,61 @@ pub async fn spamd(
         }
     });
 
-    // async-safe handle
-    let is_finished = finished.clone();
-
     let InitializedScenario {
         mut scenario,
         rpc_client,
     } = init_scenario(db, &args).await?;
 
-    // runs spam command in an async loop; in closure for tokio::select to handle CTRL-C
-    let spam_loop = || async move {
-        loop {
-            if is_finished.load(Ordering::SeqCst) {
-                println!("Spam loop finished");
-                break;
-            }
-            let args = SpamCommandArgs {
-                testfile: testfile.clone(),
-                rpc_url: rpc.to_owned(),
-                builder_url: builder_url.clone(),
-                txs_per_block: *txs_per_block,
-                txs_per_second: *txs_per_second,
-                duration: *duration,
-                seed: seed.clone(),
-                private_keys: private_keys.clone(),
-                disable_reporting: *disable_reporting,
-                min_balance: min_balance.clone(),
-                tx_type: *tx_type,
-                gas_price_percent_add: *gas_price_percent_add,
-            };
-            let db = db.clone();
-            let spam_res = commands::spam(&db, args, &mut scenario, &rpc_client).await;
-            if let Err(e) = spam_res {
-                println!("spam failed: {:?}", e);
-            } else {
-                println!("spam batch completed");
-                let run_id = spam_res.expect("spam");
-                if let Some(run_id) = run_id {
-                    // run_ids.push(run_id);
-                    run_id_sender
-                        .send(run_id)
-                        .await
-                        .expect("failed to send run ID");
-                }
-            }
+    // collects run IDs from the spam command
+    let mut run_ids = vec![];
+
+    // if CTRL-C signal is received, set `finished` to true
+    let is_finished = finished.clone();
+    tokio::task::spawn(async move {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to listen for CTRL-C");
+        println!(
+            "CTRL-C received. Spam daemon will shut down as soon as current batch finishes..."
+        );
+        is_finished.store(true, Ordering::SeqCst);
+    });
+
+    // runs spam command in a loop
+    loop {
+        if finished.load(Ordering::SeqCst) {
+            println!("Spam loop finished");
+            break;
         }
-
-        Ok::<_, ContenderError>(())
-    };
-
-    tokio::select! {
-        _ = spam_loop() => {},
-        _ = tokio::signal::ctrl_c() => {
-            println!("CTRL-C received, stopping spam daemon...");
+        let args = SpamCommandArgs {
+            testfile: testfile.clone(),
+            rpc_url: rpc.to_owned(),
+            builder_url: builder_url.clone(),
+            txs_per_block: *txs_per_block,
+            txs_per_second: *txs_per_second,
+            duration: *duration,
+            seed: seed.clone(),
+            private_keys: private_keys.clone(),
+            disable_reporting: *disable_reporting,
+            min_balance: min_balance.clone(),
+            tx_type: *tx_type,
+            gas_price_percent_add: *gas_price_percent_add,
+        };
+        let db = db.clone();
+        let spam_res = commands::spam(&db, args, &mut scenario, &rpc_client).await;
+        if let Err(e) = spam_res {
+            println!("spam failed: {:?}", e);
+        } else {
+            println!("spam batch completed");
+            let run_id = spam_res.expect("spam");
+            if let Some(run_id) = run_id {
+                run_ids.push(run_id);
+            }
         }
     }
 
-    run_id_receiver.close();
-
     // generate a report if requested; in closure for tokio::select to handle CTRL-C
     let run_report = || async move {
-        let mut run_ids = vec![];
-        while let Some(run_id) = run_id_receiver.recv().await {
-            run_ids.push(run_id);
-        }
-
         if gen_report {
             if run_ids.is_empty() {
                 println!("No runs found, exiting.");

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -12,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+/// Runs spam in a loop, potentially executing multiple spam runs.
 pub async fn spamd(
     db: &(impl DbOps + Clone + Send + Sync + 'static),
     args: SpamCommandArgs,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,7 +5,10 @@ mod util;
 use std::sync::LazyLock;
 
 use alloy::hex;
-use commands::{ContenderCli, ContenderSubcommand, DbCommand, RunCommandArgs, SpamCommandArgs};
+use commands::{
+    common::{ScenarioSendTxsCliArgs, SendSpamCliArgs},
+    ContenderCli, ContenderSubcommand, DbCommand, RunCommandArgs, SpamCliArgs, SpamCommandArgs,
+};
 use contender_core::{db::DbOps, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
 use rand::Rng;
@@ -59,12 +62,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
 
         ContenderSubcommand::Setup {
-            testfile,
-            rpc_url,
-            private_keys,
-            min_balance,
-            seed,
-            tx_type,
+            args:
+                ScenarioSendTxsCliArgs {
+                    testfile,
+                    rpc_url,
+                    private_keys,
+                    min_balance,
+                    seed,
+                    tx_type,
+                },
         } => {
             let seed = seed.unwrap_or(stored_seed);
             commands::setup(
@@ -80,19 +86,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         ContenderSubcommand::Spam {
-            testfile,
-            rpc_url,
-            builder_url,
-            txs_per_block,
-            txs_per_second,
-            duration,
-            seed,
-            private_keys,
-            disable_reports,
-            min_balance,
-            gen_report,
-            tx_type,
-            gas_price_percent_add,
+            args:
+                SpamCliArgs {
+                    eth_json_rpc_args:
+                        ScenarioSendTxsCliArgs {
+                            testfile,
+                            rpc_url,
+                            seed,
+                            private_keys,
+                            min_balance,
+                            tx_type,
+                        },
+                    spam_args:
+                        SendSpamCliArgs {
+                            duration,
+                            txs_per_block,
+                            txs_per_second,
+                            builder_url,
+                        },
+                    disable_reports,
+                    gen_report,
+                    gas_price_percent_add,
+                },
         } => {
             let seed = seed.unwrap_or(stored_seed);
             let run_id = commands::spam(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -132,7 +132,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 mut scenario,
                 rpc_client,
             } = init_scenario(&db, &spam_args).await?;
-            let run_id = commands::spam(&db, spam_args, &mut scenario, &rpc_client).await?;
+            let run_id = commands::spam(&db, &spam_args, &mut scenario, &rpc_client).await?;
             if gen_report {
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,7 +7,8 @@ use std::sync::LazyLock;
 use alloy::hex;
 use commands::{
     common::{ScenarioSendTxsCliArgs, SendSpamCliArgs},
-    ContenderCli, ContenderSubcommand, DbCommand, RunCommandArgs, SpamCliArgs, SpamCommandArgs,
+    ContenderCli, ContenderSubcommand, DbCommand, RunCommandArgs, SetupCliArgs, SpamCliArgs,
+    SpamCommandArgs,
 };
 use contender_core::{db::DbOps, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
@@ -63,13 +64,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         ContenderSubcommand::Setup {
             args:
-                ScenarioSendTxsCliArgs {
-                    testfile,
-                    rpc_url,
-                    private_keys,
-                    min_balance,
-                    seed,
-                    tx_type,
+                SetupCliArgs {
+                    args:
+                        ScenarioSendTxsCliArgs {
+                            testfile,
+                            rpc_url,
+                            private_keys,
+                            min_balance,
+                            seed,
+                            tx_type,
+                        },
                 },
         } => {
             let seed = seed.unwrap_or(stored_seed);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,8 +7,8 @@ use std::sync::LazyLock;
 use alloy::hex;
 use commands::{
     common::{ScenarioSendTxsCliArgs, SendSpamCliArgs},
-    init_scenario, ContenderCli, ContenderSubcommand, DbCommand, InitializedScenario,
-    RunCommandArgs, SetupCliArgs, SpamCliArgs, SpamCommandArgs,
+    ContenderCli, ContenderSubcommand, DbCommand, InitializedScenario, RunCommandArgs,
+    SetupCliArgs, SpamCliArgs, SpamCommandArgs,
 };
 use contender_core::{db::DbOps, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
@@ -131,7 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let InitializedScenario {
                 mut scenario,
                 rpc_client,
-            } = init_scenario(&db, &spam_args).await?;
+            } = spam_args.init_scenario(&db).await?;
             let run_id = commands::spam(&db, &spam_args, &mut scenario, &rpc_client).await?;
             if gen_report {
                 tokio::select! {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             txs_per_second,
                             builder_url,
                         },
-                    disable_reports,
+                    disable_reporting,
                     gen_report,
                     gas_price_percent_add,
                 },
@@ -125,7 +125,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     duration,
                     seed,
                     private_keys,
-                    disable_reports,
+                    disable_reporting,
                     min_balance,
                     tx_type: tx_type.into(),
                     gas_price_percent_add,
@@ -135,6 +135,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if gen_report {
                 commands::report(Some(run_id), 0, &db, &rpc_url).await?;
             }
+        }
+
+        ContenderSubcommand::SpamD {
+            args:
+                SpamCliArgs {
+                    eth_json_rpc_args:
+                        ScenarioSendTxsCliArgs {
+                            testfile,
+                            rpc_url,
+                            seed,
+                            private_keys,
+                            min_balance,
+                            tx_type,
+                        },
+                    spam_args:
+                        SendSpamCliArgs {
+                            duration,
+                            txs_per_block,
+                            txs_per_second,
+                            builder_url,
+                        },
+                    disable_reporting,
+                    gen_report,
+                    gas_price_percent_add,
+                },
+        } => {
+            let seed = seed.unwrap_or(stored_seed);
+            println!("running spamd");
         }
 
         ContenderSubcommand::Report {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,8 +7,8 @@ use std::sync::LazyLock;
 use alloy::hex;
 use commands::{
     common::{ScenarioSendTxsCliArgs, SendSpamCliArgs},
-    init_spam, ContenderCli, ContenderSubcommand, DbCommand, InitializedSpammer, RunCommandArgs,
-    SetupCliArgs, SpamCliArgs, SpamCommandArgs,
+    init_scenario, ContenderCli, ContenderSubcommand, DbCommand, InitializedScenario,
+    RunCommandArgs, SetupCliArgs, SpamCliArgs, SpamCommandArgs,
 };
 use contender_core::{db::DbOps, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
@@ -128,10 +128,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 tx_type: tx_type.into(),
                 gas_price_percent_add,
             };
-            let InitializedSpammer {
+            let InitializedScenario {
                 mut scenario,
                 rpc_client,
-            } = init_spam(&db, &spam_args).await?;
+            } = init_scenario(&db, &spam_args).await?;
             let run_id = commands::spam(&db, spam_args, &mut scenario, &rpc_client).await?;
             if gen_report {
                 tokio::select! {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -282,7 +282,7 @@ pub async fn find_insufficient_balances(
 
 pub async fn spam_callback_default(
     log_txs: bool,
-    rpc_client: Option<&AnyProvider>,
+    rpc_client: Option<&Arc<AnyProvider>>,
 ) -> SpamCallbackType {
     if let Some(rpc_client) = rpc_client {
         if log_txs {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -282,11 +282,11 @@ pub async fn find_insufficient_balances(
 
 pub async fn spam_callback_default(
     log_txs: bool,
-    rpc_client: Option<Arc<AnyProvider>>,
+    rpc_client: Option<&AnyProvider>,
 ) -> SpamCallbackType {
     if let Some(rpc_client) = rpc_client {
         if log_txs {
-            return SpamCallbackType::Log(LogCallback::new(rpc_client.clone()));
+            return SpamCallbackType::Log(LogCallback::new(rpc_client));
         }
     }
     SpamCallbackType::Nil(NilCallback)

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -28,8 +28,10 @@ pub struct LogCallback {
 }
 
 impl LogCallback {
-    pub fn new(rpc_provider: Arc<AnyProvider>) -> Self {
-        Self { rpc_provider }
+    pub fn new(rpc_provider: &AnyProvider) -> Self {
+        Self {
+            rpc_provider: Arc::new(rpc_provider.to_owned()),
+        }
     }
 }
 

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -28,9 +28,9 @@ pub struct LogCallback {
 }
 
 impl LogCallback {
-    pub fn new(rpc_provider: &AnyProvider) -> Self {
+    pub fn new(rpc_provider: &Arc<AnyProvider>) -> Self {
         Self {
-            rpc_provider: Arc::new(rpc_provider.to_owned()),
+            rpc_provider: rpc_provider.clone(),
         }
     }
 }


### PR DESCRIPTION
## Motivation

run contender for a long time, or indefinitely.

## Solution

New CLI command `spamd`, accepts same parameters as `spam` command, with an additional `time_limit` param. The main difference between `spam` and `spamd` is that in `spamd`, `commands::spam` is executed in a loop, whereas it's only executed once in `spam`. The `time_limit` parameter is optional -- if it's None, spamd will run indefinitely. If it's Some, the spam loop will exit after both the time limit has been exceeded, and the current spam batch is finished processing (so that time limit doesn't prevent us from collecting results).

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes