### PR TITLE
drop stalled txs

### DIFF
--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -80,4 +80,14 @@ Requires --priv-key to be set for each 'from' address in the given testfile.",
         long_help = "Duration of the spamming run in seconds or blocks, depending on whether --txs-per-second or --txs-per-block is set."
     )]
     pub duration: u64,
+
+    /// The time to wait for pending transactions to land, in seconds.
+    #[arg(
+        short = 'w',
+        long,
+        default_value = "12",
+        long_help = "The number of seconds to wait for pending transactions to land.",
+        visible_aliases = &["wait"]
+    )]
+    pub timeout: u64,
 }

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -60,7 +60,7 @@ pub struct SendSpamCliArgs {
     /// The number of txs to send per second using the timed spammer. This is the default spammer.
     /// May not be set if `txs_per_block` is set.
     #[arg(long, long_help = "Number of txs to send per second. Must not be set if --txs-per-block is set.", visible_aliases = &["tps"])]
-    pub txs_per_second: Option<usize>,
+    pub txs_per_second: Option<u64>,
 
     /// The number of txs to send per block using the blockwise spammer.
     /// May not be set if `txs_per_second` is set. Requires `prv_keys` to be set.
@@ -70,14 +70,14 @@ pub struct SendSpamCliArgs {
 "Number of txs to send per block. Must not be set if --txs-per-second is set.
 Requires --priv-key to be set for each 'from' address in the given testfile.",
         visible_aliases = &["tpb"])]
-    pub txs_per_block: Option<usize>,
+    pub txs_per_block: Option<u64>,
 
     /// The duration of the spamming run in seconds or blocks, depending on whether `txs_per_second` or `txs_per_block` is set.
     #[arg(
         short,
         long,
-        default_value = "10",
+        default_value = "1",
         long_help = "Duration of the spamming run in seconds or blocks, depending on whether --txs-per-second or --txs-per-block is set."
     )]
-    pub duration: Option<usize>,
+    pub duration: u64,
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -80,6 +80,7 @@ pub async fn run(
             agent_store: AgentStore::default(),
             tx_type: args.tx_type,
             gas_price_percent_add: None, // TODO: support this here !!!
+            pending_tx_timeout_secs: 12,
         },
     )
     .await?;

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -118,6 +118,7 @@ pub async fn setup(
             agent_store: agents,
             tx_type,
             gas_price_percent_add: None,
+            pending_tx_timeout_secs: 12,
         },
     )
     .await?;

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -38,7 +38,8 @@ pub struct SpamCommandArgs {
     pub disable_reporting: bool,
     pub min_balance: String,
     pub tx_type: TxType,
-    pub gas_price_percent_add: Option<u16>,
+    pub gas_price_percent_add: Option<u64>,
+    pub timeout_secs: u64,
 }
 
 impl SpamCommandArgs {
@@ -82,7 +83,7 @@ pub struct SpamCliArgs {
         long,
         long_help = "Adds given percent increase to the standard gas price of the transactions."
     )]
-    pub gas_price_percent_add: Option<u16>,
+    pub gas_price_percent_add: Option<u64>,
 }
 
 pub struct InitializedScenario<D = SqliteDb, S = RandSeed, P = TestConfig>
@@ -113,6 +114,7 @@ async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
         private_keys,
         tx_type,
         gas_price_percent_add,
+        timeout_secs,
         ..
     } = &args;
 
@@ -196,6 +198,7 @@ async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
             agent_store: agents.to_owned(),
             tx_type: *tx_type,
             gas_price_percent_add: *gas_price_percent_add,
+            pending_tx_timeout_secs: *timeout_secs,
         },
     )
     .await?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -107,6 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             txs_per_block,
                             txs_per_second,
                             builder_url,
+                            timeout,
                         },
                     disable_reporting,
                     gen_report,
@@ -127,6 +128,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 min_balance,
                 tx_type: tx_type.into(),
                 gas_price_percent_add,
+                timeout_secs: timeout,
             };
             let InitializedScenario {
                 mut scenario,
@@ -165,6 +167,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         txs_per_block,
                         txs_per_second,
                         builder_url,
+                        timeout,
                     },
                 disable_reporting,
                 gen_report,
@@ -185,6 +188,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 min_balance,
                 tx_type: tx_type.into(),
                 gas_price_percent_add,
+                timeout_secs: timeout,
             };
             commands::spamd(&db, spam_args, gen_report, time_limit).await?;
         }

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -202,6 +202,8 @@ pub async fn fund_accounts(
                 tx_type,
             )
             .await;
+
+            // TODO: figure out how to handle this error (not type-safe?)
             match res.ok() {
                 Some(res) => sender.send(res).await.expect("failed to handle pending tx"),
                 None => {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -171,30 +171,45 @@ pub async fn fund_accounts(
     let (sender, mut receiver) = tokio::sync::mpsc::channel::<PendingTransactionConfig>(9000);
     let sendr = Arc::new(sender.clone());
     let rpc_client = Arc::new(rpc_client.to_owned());
-    for (idx, (address, _)) in insufficient_balances.into_iter().enumerate() {
-        let (balance_sufficient, balance) =
-            is_balance_sufficient(&fund_with.address(), min_balance, &rpc_client).await?;
-        if !balance_sufficient {
-            // error early if admin account runs out of funds
-            return Err(format!(
-                "User account {} has insufficient balance to fund account {}. Have {}, needed {}. Chain ID: {}",
+
+    let (balance_sufficient, balance) = is_balance_sufficient(
+        &fund_with.address(),
+        min_balance * U256::from(insufficient_balances.len()),
+        &rpc_client,
+    )
+    .await?;
+    if !balance_sufficient {
+        // error early if admin account runs out of funds
+        return Err(format!(
+                "User account {} has insufficient balance to fund spammer agents. Have {}, needed {}. Chain ID: {}",
                 fund_with.address(),
-                address,
                 format_ether(balance),
                 format_ether(min_balance),
                 chain_id,
             )
             .into());
-        }
+    }
 
+    if !insufficient_balances.is_empty() {
+        let s = if insufficient_balances.len() == 1 {
+            ""
+        } else {
+            "s"
+        };
+        println!(
+            "sending funding txs ({} account{s})...",
+            insufficient_balances.len()
+        );
+    }
+    for (idx, (address, _)) in insufficient_balances.into_iter().enumerate() {
         let fund_amount = min_balance;
         let fund_with = fund_with.to_owned();
         let sender = sendr.clone();
-
         let rpc = rpc_client.clone();
+
         fund_handles.push(tokio::task::spawn(async move {
             let res = fund_account(
-                &fund_with.to_owned(),
+                &fund_with,
                 address,
                 fund_amount,
                 &rpc,
@@ -212,8 +227,9 @@ pub async fn fund_accounts(
             }
         }));
     }
+
     if !fund_handles.is_empty() {
-        println!("sending funding txs...");
+        println!("waiting for funding tasks to finish...");
         for handle in fund_handles {
             handle.await?;
         }

--- a/crates/core/src/spammer/blockwise.rs
+++ b/crates/core/src/spammer/blockwise.rs
@@ -127,6 +127,7 @@ mod tests {
                 agent_store: agents,
                 tx_type,
                 gas_price_percent_add: None,
+                pending_tx_timeout_secs: 12,
             },
         )
         .await

--- a/crates/core/src/spammer/spammer_trait.rs
+++ b/crates/core/src/spammer/spammer_trait.rs
@@ -78,21 +78,21 @@ where
             if !flush_finished {
                 println!("Result collection terminated. Some pending txs may not have been saved to the database.");
                 println!("Saving unconfirmed txs to DB. Press CTRL-C again to stop...");
+                // clear out unconfirmed txs from the cache
+                let dump_finished: bool = tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {
+                        println!("\nCTRL-C received, stopping tx cache dump...");
+                        false
+                    },
+                    _ = scenario.dump_tx_cache(run_id) => {
+                        true
+                    }
+                };
+                if !dump_finished {
+                    println!("Tx cache dump terminated. Some unconfirmed txs may not have been saved to the database.");
+                }
             }
 
-            // clear out unconfirmed txs from the cache
-            let dump_finished: bool = tokio::select! {
-                _ = tokio::signal::ctrl_c() => {
-                    println!("\nCTRL-C received, stopping tx cache dump...");
-                    false
-                },
-                _ = scenario.dump_tx_cache(run_id) => {
-                    true
-                }
-            };
-            if !dump_finished {
-                println!("Tx cache dump terminated. Some unconfirmed txs may not have been saved to the database.");
-            }
             let run_id = run_id
                 .map(|id| format!("run_id: {}", id))
                 .unwrap_or_default();

--- a/crates/core/src/spammer/spammer_trait.rs
+++ b/crates/core/src/spammer/spammer_trait.rs
@@ -71,26 +71,26 @@ where
                     let _ = scenario.msg_handle.stop().await;
                     false
                 },
-                _ = scenario.flush_tx_cache(start_block, run_id) => {
+                _ = scenario.flush_tx_cache(start_block, run_id.unwrap_or(0)) => {
                     true
                 }
             };
             if !flush_finished {
                 println!("Result collection terminated. Some pending txs may not have been saved to the database.");
-                println!("Saving unconfirmed txs to DB. Press CTRL-C again to stop...");
-                // clear out unconfirmed txs from the cache
-                let dump_finished: bool = tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {
-                        println!("\nCTRL-C received, stopping tx cache dump...");
-                        false
-                    },
-                    _ = scenario.dump_tx_cache(run_id) => {
-                        true
-                    }
-                };
-                if !dump_finished {
-                    println!("Tx cache dump terminated. Some unconfirmed txs may not have been saved to the database.");
+            }
+
+            // clear out unconfirmed txs from the cache
+            let dump_finished: bool = tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    println!("\nCTRL-C received, stopping tx cache dump...");
+                    false
+                },
+                _ = scenario.dump_tx_cache(run_id.unwrap_or(0)) => {
+                    true
                 }
+            };
+            if !dump_finished {
+                println!("Tx cache dump terminated. Some unconfirmed txs may not have been saved to the database.");
             }
 
             let run_id = run_id

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -319,7 +319,15 @@ where
                 } => {
                     Self::handle_message(&mut self.cache, &self.db, &self.rpc, msg).await?;
                 }
-                _ => {}
+                TxActorMessage::RemovedRunTx {
+                    tx_hash: _,
+                    on_remove: _,
+                } => {
+                    Self::handle_message(&mut self.cache, &self.db, &self.rpc, msg).await?;
+                }
+                TxActorMessage::Stop { on_stop: _ } => {
+                    // do nothing here; stop is a signal to interrupt other message handlers
+                }
             }
         }
         Ok(())

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -210,9 +210,10 @@ where
         let old_tx = cache
             .iter()
             .position(|tx| tx.tx_hash == old_tx_hash)
-            .ok_or_else(|| {
-                ContenderError::SpamError("failed to find tx in cache to replace", None)
-            })?;
+            .ok_or(ContenderError::SpamError(
+                "failed to find tx in cache to replace",
+                None,
+            ))?;
         cache.remove(old_tx);
         Ok(())
     }

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -5,7 +5,7 @@ use tokio::task::JoinHandle;
 
 use crate::generator::{types::AnyProvider, NamedTxRequest};
 
-use super::tx_actor::TxActorHandle;
+use super::tx_actor::{CacheTx, TxActorHandle};
 
 pub trait OnTxSent<K = String, V = String>
 where
@@ -68,8 +68,14 @@ impl OnTxSent for LogCallback {
             .and_then(|e| e.get("error").map(|e| e.to_owned()));
         let handle = tokio::task::spawn(async move {
             if let Some(tx_actor) = tx_actor {
+                let tx = CacheTx {
+                    tx_hash: *tx_response.tx_hash(),
+                    start_timestamp,
+                    kind,
+                    error,
+                };
                 tx_actor
-                    .cache_run_tx(*tx_response.tx_hash(), start_timestamp, kind, error)
+                    .cache_run_tx(tx)
                     .await
                     .expect("failed to cache run tx");
             }

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -388,6 +388,7 @@ pub mod tests {
                 agent_store: Default::default(),
                 tx_type,
                 gas_price_percent_add: None,
+                pending_tx_timeout_secs: 12,
             },
         )
         .await
@@ -433,6 +434,7 @@ pub mod tests {
                 agent_store: Default::default(),
                 tx_type,
                 gas_price_percent_add: None,
+                pending_tx_timeout_secs: 12,
             },
         )
         .await
@@ -448,6 +450,7 @@ pub mod tests {
                 agent_store: Default::default(),
                 tx_type,
                 gas_price_percent_add: None,
+                pending_tx_timeout_secs: 12,
             },
         )
         .await


### PR DESCRIPTION
## Motivation

If your spam txs get stuck in the tx pool (meaning they were received by the RPC as a valid tx but haven't been included onchain) then we would get stuck waiting for them, forcing us to shutdown our spam run or wait a long time.

## Solution

Add a timeout that activates when the result collector hasn't seen any changes in the cache for some number of seconds. When the timeout is triggered, any txs that have been sitting in the cache for longer than the timeout will be removed. This allows `spamd` to start another run, generating new txs to replace the stalled ones.

The default timeout is `12` seconds. This can be changed by passing a CLI flag: `--timeout`, `--wait`, or `-w`

I also changed the default `duration` for spam commands to 1. If there are errors present, you should now see them sooner and not have to wait as long for contender to retry.

Usage examples:

Wait for 6 seconds before discarding stalled txs:
```bash
cargo run -- spamd ./scenarios/simpler.toml $C_URL -p $PRK --min-balance 0.001 --tps 150 -w 6
```

Increase the gas price by 25% (sometimes useful for overcoming "replacement transaction underpriced" errors):
```bash
cargo run -- spamd ./scenarios/simpler.toml $C_URL -p $PRK --min-balance 0.001 --tps 150 -w 6 -g 25
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes