### PR TITLE
gas price adder & priority fee bugfix

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub use db::*;
 pub use report::report;
 pub use run::{run, RunCommandArgs};
 pub use setup::{setup, SetupCliArgs};
-pub use spam::{spam, InitializedScenario, SpamCliArgs, SpamCommandArgs};
+pub use spam::{spam, SpamCliArgs, SpamCommandArgs};
 pub use spamd::spamd;
 
 #[derive(Parser, Debug)]

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -21,7 +21,6 @@ use contender_core::{
     spammer::{BlockwiseSpammer, Spammer, TimedSpammer},
     test_scenario::{TestScenario, TestScenarioParams},
 };
-use contender_sqlite::SqliteDb;
 use contender_testfile::TestConfig;
 use std::sync::Arc;
 
@@ -46,7 +45,7 @@ impl SpamCommandArgs {
     pub async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
         &self,
         db: &D,
-    ) -> Result<InitializedScenario<D>, Box<dyn std::error::Error>> {
+    ) -> Result<TestScenario<D, RandSeed, TestConfig>, Box<dyn std::error::Error>> {
         init_scenario(db, self).await
     }
 }
@@ -86,21 +85,11 @@ pub struct SpamCliArgs {
     pub gas_price_percent_add: Option<u64>,
 }
 
-pub struct InitializedScenario<D = SqliteDb, S = RandSeed, P = TestConfig>
-where
-    D: DbOps + Clone + Send + Sync + 'static,
-    S: Seeder,
-    P: PlanConfig<String> + Templater<String> + Send + Sync,
-{
-    pub scenario: TestScenario<D, S, P>,
-    pub rpc_client: AnyProvider,
-}
-
 /// Initializes a TestScenario with the given arguments.
 async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
     db: &D,
     args: &SpamCommandArgs,
-) -> Result<InitializedScenario<D>, Box<dyn std::error::Error>> {
+) -> Result<TestScenario<D, RandSeed, TestConfig>, Box<dyn std::error::Error>> {
     println!("Initializing spammer...");
     let SpamCommandArgs {
         txs_per_block,
@@ -218,10 +207,7 @@ async fn init_scenario<D: DbOps + Clone + Send + Sync + 'static>(
         .into());
     }
 
-    Ok(InitializedScenario {
-        scenario,
-        rpc_client,
-    })
+    Ok(scenario)
 }
 
 /// Runs spammer and returns run ID.

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -58,6 +58,8 @@ pub async fn spamd(
             println!("Spam loop finished");
             break;
         }
+        println!("syncing nonces...");
+        scenario.sync_nonces().await?;
         let db = db.clone();
         let spam_res = commands::spam(&db, &args, &mut scenario, &rpc_client).await;
         if let Err(e) = spam_res {

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -1,5 +1,5 @@
 use super::SpamCommandArgs;
-use crate::commands::{self, spam::InitializedScenario};
+use crate::commands::{self};
 use contender_core::{db::DbOps, error::ContenderError};
 use std::{
     sync::{
@@ -32,10 +32,8 @@ pub async fn spamd(
         }
     });
 
-    let InitializedScenario {
-        mut scenario,
-        rpc_client,
-    } = args.init_scenario(db).await?;
+    let mut scenario = args.init_scenario(db).await?;
+    let rpc_client = scenario.rpc_client.clone();
 
     // collects run IDs from the spam command
     let mut run_ids = vec![];

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,8 +7,8 @@ use std::sync::LazyLock;
 use alloy::hex;
 use commands::{
     common::{ScenarioSendTxsCliArgs, SendSpamCliArgs},
-    ContenderCli, ContenderSubcommand, DbCommand, InitializedScenario, RunCommandArgs,
-    SetupCliArgs, SpamCliArgs, SpamCommandArgs,
+    ContenderCli, ContenderSubcommand, DbCommand, RunCommandArgs, SetupCliArgs, SpamCliArgs,
+    SpamCommandArgs,
 };
 use contender_core::{db::DbOps, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
@@ -130,10 +130,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 gas_price_percent_add,
                 timeout_secs: timeout,
             };
-            let InitializedScenario {
-                mut scenario,
-                rpc_client,
-            } = spam_args.init_scenario(&db).await?;
+            let mut scenario = spam_args.init_scenario(&db).await?;
+            let rpc_client = scenario.rpc_client.clone();
             let run_id = commands::spam(&db, &spam_args, &mut scenario, &rpc_client).await?;
             if gen_report {
                 tokio::select! {

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -133,7 +133,7 @@ where
             }
         }
         let block_time_secs = if timestamps.len() == 2 {
-            (timestamps[1] - timestamps[0]).max(1)
+            (timestamps[0] - timestamps[1]).max(1)
         } else {
             1
         };

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -119,9 +119,13 @@ where
 
         // derive block time from last two blocks. if two blocks don't exist, assume block time is 1s
         let mut timestamps = vec![];
+        let block_num = rpc_client
+            .get_block_number()
+            .await
+            .map_err(|e| ContenderError::with_err(e, "failed to get block number"))?;
         for i in [0_u64, 1] {
             let block = rpc_client
-                .get_block_by_number(i.into())
+                .get_block_by_number((block_num - i).into())
                 .await
                 .map_err(|e| ContenderError::with_err(e, "failed to get block"))?;
             if let Some(block) = block {
@@ -129,7 +133,7 @@ where
             }
         }
         let block_time_secs = if timestamps.len() == 2 {
-            timestamps[1] - timestamps[0]
+            (timestamps[1] - timestamps[0]).max(1)
         } else {
             1
         };

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -596,7 +596,7 @@ where
             .map_err(|e| ContenderError::with_err(e, "failed to get gas price"))?;
         let gas_price = gas_price + ((gas_price * self.gas_price_percent_add as u128) / 100);
         let gas_price = if self.ctx.gas_price_adder < 0 {
-            gas_price - self.ctx.gas_price_adder.abs() as u128
+            gas_price - self.ctx.gas_price_adder.unsigned_abs()
         } else {
             gas_price + self.ctx.gas_price_adder as u128
         };

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -909,7 +909,7 @@ where
             // decrease gas price if all txs were sent successfully
             success_receiver.close();
             let mut success_count = 0;
-            while let Some(_) = success_receiver.recv().await {
+            while success_receiver.recv().await.is_some() {
                 success_count += 1;
             }
             if success_count == num_payloads {

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -744,16 +744,14 @@ where
                                         .contains("replacement transaction underpriced")
                                     {
                                         // send the current gas price / 10 to increase it by 10% for the next batch
-                                        if !gas_sender.is_closed() {
-                                            gas_sender
-                                                .send(
-                                                    req.tx.max_fee_per_gas.unwrap_or(
-                                                        req.tx.gas_price.unwrap_or(1_000_000_000),
-                                                    ) / 10,
-                                                )
-                                                .await
-                                                .expect("failed to send gas update");
-                                        }
+                                        gas_sender
+                                            .send(
+                                                req.tx.max_fee_per_gas.unwrap_or(
+                                                    req.tx.gas_price.unwrap_or(1_000_000_000),
+                                                ) / 10,
+                                            )
+                                            .await
+                                            .expect("failed to send gas update");
                                     }
 
                                     // include errored txs in the cache; user may want to retry them


### PR DESCRIPTION
## Motivation

Was seeing a lot of "replacement transaction underpriced" errors.

## Solution

Started by adding a mechanism to automatically increase the gas price when we saw the error. The spammer increased the gas price a ton yet I still saw the error, which led me to find an inconspicuous bug in the priority fee calculation.

With that fixed, gas price increases happened much less frequently. I left the  `spamd` now reliably fills blocks on a live testnet until the accounts run out of gas, at which point contender must be manually stopped.

## Future improvement

In `spamd`, automatically replenish funds in agent accounts 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes