### PR TITLE
fix "intrinsic gas too low" error

### DIFF
--- a/crates/cli/src/default_scenarios/runconfig.rs
+++ b/crates/cli/src/default_scenarios/runconfig.rs
@@ -59,17 +59,9 @@ impl From<BuiltinScenarioConfig> for TestConfig {
                 sender,
                 fill_percent,
             } => {
-                let gas_per_tx = if fill_percent < 100 {
-                    ((max_gas_per_block / num_txs) / 100) * fill_percent as u64
-                } else {
-                    max_gas_per_block / num_txs
-                };
-                println!(
-                    "Filling blocks to {}% with {} gas per tx",
-                    fill_percent, gas_per_tx
-                );
-                let spam_txs = (0
-                    ..(num_txs + num_txs / 10/* add 10% to ensure block can get more than full */))
+                let gas_per_tx = (fill_percent as u64 * max_gas_per_block) / (num_txs * 100);
+                println!("Filling blocks to {fill_percent}% ({}/{max_gas_per_block}); sending {num_txs} txs with gas limit {gas_per_tx}", fill_percent as u64 * max_gas_per_block / 100);
+                let spam_txs = (0..num_txs)
                     .map(|_| {
                         SpamRequest::Tx(FunctionCallDefinition {
                             to: "{SpamMe}".to_owned(),


### PR DESCRIPTION
## Motivation

#182 

## Solution

When getting this error (`intrinsic gas too low`), it means your tx doesn't use enough gas to be considered on this chain, so you need to use more gas.

When running `contender run fill-block` with a high number of transactions, the gas limit gets shrunk down because fill-block divides the block gas limit by the number of txs.

To compensate for this, we can (should have been able to) set `C_FILL_PERCENT` in the environment.

```sh
C_FILL_PERCENT=400 cargo run -- run fill-block -i 1 http://localhost:8545 -n 1000
```

But a (pointless) conditional was preventing percentages > 100 from being parsed, so I removed it.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes