### PR TITLE
fix spam cost estimate bug

### DIFF
--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -221,7 +221,6 @@ impl SpamCommandArgs {
         )
         .await?;
 
-        // don't multiply by TPS or TPB, because that number scales the number of accounts; this cost is per account
         let total_cost = U256::from(*duration * txs_per_duration)
             * scenario.get_max_spam_cost(&user_signers).await?;
         if min_balance < U256::from(total_cost) {

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -222,7 +222,8 @@ impl SpamCommandArgs {
         .await?;
 
         // don't multiply by TPS or TPB, because that number scales the number of accounts; this cost is per account
-        let total_cost = U256::from(*duration) * scenario.get_max_spam_cost(&user_signers).await?;
+        let total_cost = U256::from(*duration * txs_per_duration)
+            * scenario.get_max_spam_cost(&user_signers).await?;
         if min_balance < U256::from(total_cost) {
             return Err(ContenderError::SpamError(
                 "min_balance is not enough to cover the cost of the spam transactions",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

invalid estimates; not erroring when it should, which causes errors later during runtime.

## Solution

we forgot to multiply the per-tx max spam cost by the total number of transactions. fixed that.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes