### PR TITLE
add debug log for failed provider calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower 0.5.2",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,6 +15,7 @@ use contender_sqlite::{SqliteDb, DB_VERSION};
 use rand::Rng;
 use std::sync::LazyLock;
 use tokio::sync::OnceCell;
+use tracing_subscriber::EnvFilter;
 use util::{data_dir, db_file};
 
 static DB: LazyLock<SqliteDb> = std::sync::LazyLock::new(|| {
@@ -28,8 +29,7 @@ static LATENCY_HIST: OnceCell<prometheus::HistogramVec> = OnceCell::const_new();
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let subscriber = tracing_subscriber::FmtSubscriber::new();
-    tracing::subscriber::set_global_default(subscriber)?;
+    init_tracing();
 
     let args = ContenderCli::parse_args();
     if DB.table_exists("run_txs")? {
@@ -279,4 +279,14 @@ Remote DB version = {}, contender expected version {}.
         }
     }
     Ok(())
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")); // fallback if RUST_LOG is unset
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_line_number(true)
+        .init();
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,3 +27,5 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tokio-util = { workspace = true }
 tower = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }


### PR DESCRIPTION
## Motivation

If an RPC error occurs, we want to log it with max detail.

## Solution

- debug! call in provider when it receives an error from `self.inner.call`

To see all debug logs, set `RUST_LOG=debug` in your environment:

```sh
RUST_LOG=debug cargo run -- spam ./scenarios/simple.toml --tps 100
```

Restricting `debug` logs to `contender_core` crate:

```sh
RUST_LOG=contender_core=debug cargo run -- spam ./scenarios/simple.toml --tps 100
```

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes