### PR TITLE
consolidate spamd

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,21 +103,19 @@ contender spam ./scenarios/stress.toml -r $RPC_URL --tps 10 -d 3 -p $PRV_KEY
 Generate a report immediately following a spam run:
 
 ```bash
-contender spam ./scenarios/stress.toml -r $RPC_URL --tps 10 -d 3 -p $PRV_KEY --gen-report
+contender spam ./scenarios/stress.toml -r $RPC_URL --tps 10 -d 3 -p $PRV_KEY --report
 ```
 
----
-
-Run spammer indefinitely:
+Run spammer indefinitely with `--loops` (`-l`):
 
 ```bash
-contender spamd ./scenarios/stress.toml -r $RPC_URL --tps 10 -d 3 -p $PRV_KEY
+contender spam ./scenarios/stress.toml -r $RPC_URL --tps 10 -d 3 -p $PRV_KEY -l
 ```
 
-Run spammer for 5 minutes:
+Loop spammer 5 times:
 
 ```bash
-contender spamd ./scenarios/stress.toml -r $RPC_URL --tps 10 -d 3 -p $PRV_KEY --tl $((60 * 5))
+contender spam ./scenarios/stress.toml -r $RPC_URL --tps 10 -d 3 -p $PRV_KEY -l 5
 ```
 
 ---

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -167,6 +167,18 @@ Requires --priv-key to be set for each 'from' address in the given testfile.",
         visible_aliases = &["wait"]
     )]
     pub timeout: u64,
+
+    /// The number of times to repeat the spam run.
+    /// If set with a value, the spam run will be repeated this many times.
+    /// If set without a value, the spam run will be repeated indefinitely.
+    /// If not set, the spam run will be repeated once.
+    #[arg(
+        short,
+        long,
+        num_args = 0..=1,
+        long_help = "The number of times to repeat the spam run. If set with a value, the spam run will be repeated this many times. If set without a value, the spam run will be repeated indefinitely. If not set, the spam run will be repeated once."
+    )]
+    pub loops: Option<Option<u64>>,
 }
 
 pub fn cli_env_vars_parser(s: &str) -> Result<(String, String), String> {

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -32,23 +32,6 @@ pub enum ContenderSubcommand {
     },
 
     #[command(
-        name = "spamd",
-        long_about = "Run spam in a loop over a long duration or indefinitely."
-    )]
-    SpamD {
-        #[command(flatten)]
-        spam_inner_args: SpamCliArgs,
-
-        #[arg(
-            short = 'l',
-            long,
-            long_help = "The time limit in seconds for the spam daemon. If not provided, the daemon will run indefinitely.",
-            visible_aliases = &["tl"]
-        )]
-        time_limit: Option<u64>,
-    },
-
-    #[command(
         name = "setup",
         long_about = "Deploy contracts and run the setup step(s) in the given testfile."
     )]

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -40,15 +40,18 @@ pub async fn spamd(
     // runs spam command in a loop
     let mut i = 0;
     loop {
+        let mut do_finish = false;
         if let Some(loops) = &limit_loops {
             if i >= *loops {
-                println!("Spam loop finished");
-                break;
+                do_finish = true;
             }
             i += 1;
         }
         if finished.load(Ordering::SeqCst) {
-            println!("Spam loop finished");
+            do_finish = true;
+        }
+        if do_finish {
+            println!("Spam loop finished.");
             break;
         }
         println!("syncing nonces...");

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -8,16 +8,16 @@ use std::sync::{
 
 /// Runs spam in a loop, potentially executing multiple spam runs.
 ///
-/// If `loops` is `None`, it will run indefinitely.
+/// If `limit_loops` is `None`, it will run indefinitely.
 ///
-/// If `loops` is `Some(n)`, it will run `n` times.
+/// If `limit_loops` is `Some(n)`, it will run `n` times.
 ///
 /// If `gen_report` is `true`, it will generate a report at the end.
 pub async fn spamd(
     db: &(impl DbOps + Clone + Send + Sync + 'static),
     args: SpamCommandArgs,
     gen_report: bool,
-    loops: Option<u64>,
+    limit_loops: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let finished = Arc::new(AtomicBool::new(false));
     let mut scenario = args.init_scenario(db).await?;
@@ -40,7 +40,7 @@ pub async fn spamd(
     // runs spam command in a loop
     let mut i = 0;
     loop {
-        if let Some(loops) = &loops {
+        if let Some(loops) = &limit_loops {
             if i >= *loops {
                 println!("Spam loop finished");
                 break;

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -131,7 +131,6 @@ async fn init_metrics(registry: &OnceCell<Registry>, latency_hist: &OnceCell<His
 #[cfg(test)]
 pub mod tests {
     use alloy::rpc::json_rpc::Id;
-    use tracing::Level;
     use tracing_subscriber::FmtSubscriber;
 
     use super::*;
@@ -164,7 +163,7 @@ pub mod tests {
     async fn bad_request_logs_error() -> Result<()> {
         TRACING_INIT.call_once(|| {
             let subscriber = FmtSubscriber::builder()
-                .with_max_level(Level::DEBUG)
+                .with_env_filter("contender_core=debug")
                 .finish();
             tracing::subscriber::set_global_default(subscriber)
                 .expect("setting default subscriber failed");


### PR DESCRIPTION
## Motivation

https://github.com/flashbots/contender/issues/210

## Solution

Implemented as proposed in the issue.

`spam` just uses inner `spamd` function now, which made this a pretty easy job.

new flag is `--loops` (`-l`).

```sh
cargo run -- setup ./scenarios/simple.toml

# run indefinitely
cargo run -- spam ./scenarios/simple.toml --tps 100 -l

# execute 10 spam runs
cargo run -- spam ./scenarios/simple.toml --tps 100 -l 10

# send 20 batches of 100 txs (default is 1 batch) before checking receipts, loop that 10 times
cargo run -- spam ./scenarios/simple.toml --tps 100 -l 10 -d 20
```

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes