### PR TITLE
Feat/reports w runtime params

### DIFF
--- a/crates/cli/src/commands/report/block_trace.rs
+++ b/crates/cli/src/commands/report/block_trace.rs
@@ -44,8 +44,8 @@ pub async fn get_block_data(
 
     // pad block range on each side
     let block_padding = 3;
-    let min_block = min_block - block_padding;
-    let max_block = max_block + block_padding;
+    let min_block = min_block.saturating_sub(block_padding);
+    let max_block = max_block.saturating_add(block_padding);
 
     let rpc_client = Arc::new(rpc_client.clone());
 

--- a/crates/cli/src/commands/report/command.rs
+++ b/crates/cli/src/commands/report/command.rs
@@ -69,7 +69,8 @@ pub async fn report(
             }
             runtime_params_list.push(RuntimeParams {
                 txs_per_duration: run.txs_per_duration,
-                duration: run.duration,
+                duration_value: run.duration.value(),
+                duration_unit: run.duration.unit().to_owned(),
                 timeout: run.timeout,
             });
             run_data.push(run);
@@ -285,7 +286,8 @@ pub struct SpamRunMetrics {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RuntimeParams {
     pub txs_per_duration: u64,
-    pub duration: u64,
+    pub duration_value: u64,
+    pub duration_unit: String,
     pub timeout: u64,
 }
 

--- a/crates/cli/src/commands/report/command.rs
+++ b/crates/cli/src/commands/report/command.rs
@@ -60,12 +60,19 @@ pub async fn report(
 
     // get run data, filter by rpc_url
     let mut run_data = vec![];
+    let mut runtime_params_list = Vec::new();
     for id in start_run_id..=end_run_id {
         let run = db.get_run(id)?;
         if let Some(run) = run {
             if run.rpc_url != rpc_url {
                 continue;
             }
+            runtime_params_list.push(RuntimeParams {
+                run_id: run.id,
+                txs_per_duration: run.txs_per_duration,
+                duration: run.duration,
+                timeout: run.timeout,
+            });
             run_data.push(run);
         }
     }
@@ -200,6 +207,7 @@ pub async fn report(
                 method: method.to_owned(),
             })
             .collect(),
+        runtime_params: runtime_params_list,
     };
 
     // make relevant chart for each report_id
@@ -272,6 +280,15 @@ pub struct SpamRunMetrics {
     pub peak_tx_count: MetricDescriptor<u64>,
     pub average_block_time_secs: MetricDescriptor<f64>,
     pub latency_quantiles: Vec<RpcLatencyQuantiles>,
+    pub runtime_params: Vec<RuntimeParams>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RuntimeParams {
+    pub run_id: u64,
+    pub txs_per_duration: u64,
+    pub duration: u64,
+    pub timeout: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/cli/src/commands/report/command.rs
+++ b/crates/cli/src/commands/report/command.rs
@@ -68,7 +68,6 @@ pub async fn report(
                 continue;
             }
             runtime_params_list.push(RuntimeParams {
-                run_id: run.id,
                 txs_per_duration: run.txs_per_duration,
                 duration: run.duration,
                 timeout: run.timeout,
@@ -285,7 +284,6 @@ pub struct SpamRunMetrics {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RuntimeParams {
-    pub run_id: u64,
     pub txs_per_duration: u64,
     pub duration: u64,
     pub timeout: u64,

--- a/crates/cli/src/commands/report/template.html
+++ b/crates/cli/src/commands/report/template.html
@@ -223,8 +223,8 @@
     <table>
       <thead>
         <tr>
-          <th>Txs Per Duration</th>
-          <th>Duration</th>
+          <th>Txs Per Run</th>
+          <th>Run Duration</th>
           <th>Timeout</th>
         </tr>
       </thead>
@@ -232,8 +232,8 @@
         {{#each data.metrics.runtime_params}}
         <tr>
           <td>{{this.txs_per_duration}}</td>
-          <td>{{this.duration}}</td>
-          <td>{{this.timeout}}</td>
+          <td>{{this.duration_value}} {{this.duration_unit}}</td>
+          <td>{{this.timeout}} {{this.duration_unit}}</td>
         </tr>
         {{/each}}
       </tbody>

--- a/crates/cli/src/commands/report/template.html
+++ b/crates/cli/src/commands/report/template.html
@@ -223,7 +223,6 @@
     <table>
       <thead>
         <tr>
-          <th>Run ID</th>
           <th>Txs Per Duration</th>
           <th>Duration</th>
           <th>Timeout</th>
@@ -232,7 +231,6 @@
       <tbody>
         {{#each data.metrics.runtime_params}}
         <tr>
-          <td>{{this.run_id}}</td>
           <td>{{this.txs_per_duration}}</td>
           <td>{{this.duration}}</td>
           <td>{{this.timeout}}</td>

--- a/crates/cli/src/commands/report/template.html
+++ b/crates/cli/src/commands/report/template.html
@@ -217,6 +217,31 @@
     </table>
   </section>
 
+
+  <section>
+    <h2>Runtime Parameters</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Run ID</th>
+          <th>Txs Per Duration</th>
+          <th>Duration</th>
+          <th>Timeout</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each data.metrics.runtime_params}}
+        <tr>
+          <td>{{this.run_id}}</td>
+          <td>{{this.txs_per_duration}}</td>
+          <td>{{this.duration}}</td>
+          <td>{{this.timeout}}</td>
+        </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </section>
+
   {{#each data.charts}}
   <section>
     <h2>

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -161,7 +161,7 @@ pub async fn run(
         scenario.rpc_url.as_str(),
         args.txs_per_duration,
         args.duration,
-        12 // Since pending_tx_timeout is set to 12
+        12, // Since pending_tx_timeout is set to 12
     )?;
     let provider = Arc::new(DynProvider::new(provider));
     let tx_callback = LogCallback::new(

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -159,6 +159,9 @@ pub async fn run(
         args.duration * args.txs_per_duration,
         &format!("{contract_name} ({scenario_name})"),
         scenario.rpc_url.as_str(),
+        args.txs_per_duration,
+        args.duration,
+        12 // Since pending_tx_timeout is set to 12
     )?;
     let provider = Arc::new(DynProvider::new(provider));
     let tx_callback = LogCallback::new(

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -268,6 +268,7 @@ pub async fn spam<
         duration,
         disable_reporting,
         engine_params,
+        timeout_secs,
         ..
     } = args;
 
@@ -329,6 +330,9 @@ pub async fn spam<
                     txs_per_block * duration,
                     testfile,
                     test_scenario.rpc_url.as_str(),
+                    *txs_per_block,
+                    *duration,
+                    *timeout_secs
                 )?);
                 spammer
                     .spam_rpc(
@@ -378,6 +382,9 @@ pub async fn spam<
                 tps * duration,
                 testfile,
                 test_scenario.rpc_url.as_str(),
+                tps,
+                *duration,
+                *timeout_secs,
             )?);
             spammer
                 .spam_rpc(test_scenario, tps, *duration, run_id, tx_callback.into())

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -332,7 +332,7 @@ pub async fn spam<
                     test_scenario.rpc_url.as_str(),
                     *txs_per_block,
                     *duration,
-                    *timeout_secs
+                    *timeout_secs,
                 )?);
                 spammer
                     .spam_rpc(

--- a/crates/core/src/db/mock.rs
+++ b/crates/core/src/db/mock.rs
@@ -24,7 +24,7 @@ impl DbOps for MockDb {
         _rpc_url: &str,
         _txs_per_duration: u64,
         _duration: u64,
-        _timeout: u64
+        _timeout: u64,
     ) -> Result<u64> {
         Ok(0)
     }

--- a/crates/core/src/db/mock.rs
+++ b/crates/core/src/db/mock.rs
@@ -22,6 +22,9 @@ impl DbOps for MockDb {
         _tx_count: u64,
         _scenario_name: &str,
         _rpc_url: &str,
+        _txs_per_duration: u64,
+        _duration: u64,
+        _timeout: u64
     ) -> Result<u64> {
         Ok(0)
     }

--- a/crates/core/src/db/mock.rs
+++ b/crates/core/src/db/mock.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use alloy::primitives::{Address, TxHash};
 
-use super::{DbOps, NamedTx, RunTx};
+use super::{DbOps, NamedTx, RunTx, SpamRunRequest};
 use crate::{buckets::Bucket, Result};
 
 pub struct MockDb;
@@ -16,16 +16,7 @@ impl DbOps for MockDb {
         Ok(())
     }
 
-    fn insert_run(
-        &self,
-        _timestamp: u64,
-        _tx_count: u64,
-        _scenario_name: &str,
-        _rpc_url: &str,
-        _txs_per_duration: u64,
-        _duration: u64,
-        _timeout: u64,
-    ) -> Result<u64> {
+    fn insert_run(&self, _run: &SpamRunRequest) -> Result<u64> {
         Ok(0)
     }
 

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -69,8 +69,8 @@ impl SpamDuration {
 impl Display for SpamDuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SpamDuration::Seconds(v) => write!(f, "{} seconds", v),
-            SpamDuration::Blocks(v) => write!(f, "{} blocks", v),
+            SpamDuration::Seconds(v) => write!(f, "{v} seconds"),
+            SpamDuration::Blocks(v) => write!(f, "{v} blocks"),
         }
     }
 }
@@ -87,7 +87,7 @@ impl From<String> for SpamDuration {
                 return SpamDuration::Blocks(blocks);
             }
         }
-        panic!("Invalid format for SpamDuration: {}", value);
+        panic!("Invalid format for SpamDuration: {value}");
     }
 }
 

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -45,7 +45,7 @@ pub struct SpamRun {
     pub rpc_url: String,
     pub txs_per_duration: u64,
     pub duration: u64,
-    pub timeout: u64
+    pub timeout: u64,
 }
 
 pub trait DbOps {

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -65,6 +65,7 @@ pub trait DbOps {
     fn insert_named_txs(&self, named_txs: &[NamedTx], rpc_url: &str) -> Result<()>;
 
     /// Insert a new run into the database. Returns run_id.
+    #[allow(clippy::too_many_arguments)]
     fn insert_run(
         &self,
         timestamp: u64,

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -43,6 +43,9 @@ pub struct SpamRun {
     pub tx_count: usize,
     pub scenario_name: String,
     pub rpc_url: String,
+    pub txs_per_duration: u64,
+    pub duration: u64,
+    pub timeout: u64
 }
 
 pub trait DbOps {
@@ -68,6 +71,9 @@ pub trait DbOps {
         tx_count: u64,
         scenario_name: &str,
         rpc_url: &str,
+        txs_per_duration: u64,
+        duration: u64,
+        timeout: u64,
     ) -> Result<u64>;
 
     /// Insert txs from a spam run into the database.

--- a/crates/sqlite_db/Cargo.toml
+++ b/crates/sqlite_db/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "contender_sqlite"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
 authors.workspace = true
-license.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
+name = "contender_sqlite"
 repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
-contender_core = { workspace = true }
+alloy = {workspace = true}
+contender_core = {workspace = true}
+r2d2 = {workspace = true}
 r2d2_sqlite = {workspace = true}
 rusqlite = {workspace = true}
-r2d2 = {workspace = true}
-alloy = { workspace = true }
-serde = { workspace = true }
+serde = {workspace = true}

--- a/crates/sqlite_db/src/lib.rs
+++ b/crates/sqlite_db/src/lib.rs
@@ -47,7 +47,7 @@ impl SqliteDb {
         self.get_pool()?.execute(query, params).map_err(|e| {
             ContenderError::DbError(
                 "failed to execute query.",
-                Some(format!("query: \"{}\",  error: \"{}\"", query, e)),
+                Some(format!("query: \"{query}\",  error: \"{e}\"")),
             )
         })?;
         Ok(())
@@ -251,8 +251,6 @@ impl DbOps for SqliteDb {
             duration,
             timeout,
         } = run;
-        println!("INSERT INTO runs (timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration, timeout) VALUES ({}, {}, {}, {}, {}, '{}', {})",
-            timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration, timeout);
         self.execute(
             "INSERT INTO runs (timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration, timeout) VALUES (?, ?, ?, ?, ?, ?, ?)",
             params![timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, &duration.to_string(), timeout],

--- a/crates/sqlite_db/src/lib.rs
+++ b/crates/sqlite_db/src/lib.rs
@@ -252,7 +252,7 @@ impl DbOps for SqliteDb {
             timeout,
         } = run;
         println!("INSERT INTO runs (timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration, timeout) VALUES ({}, {}, {}, {}, {}, '{}', {})",
-            timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration.to_string(), timeout);
+            timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration, timeout);
         self.execute(
             "INSERT INTO runs (timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration, timeout) VALUES (?, ?, ?, ?, ?, ?, ?)",
             params![timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, &duration.to_string(), timeout],

--- a/crates/sqlite_db/src/lib.rs
+++ b/crates/sqlite_db/src/lib.rs
@@ -158,7 +158,7 @@ struct SpamRunRow {
     pub rpc_url: String,
     pub txs_per_duration: u64,
     pub duration: u64,
-    pub timeout: u64
+    pub timeout: u64,
 }
 
 impl From<SpamRunRow> for SpamRun {
@@ -171,7 +171,7 @@ impl From<SpamRunRow> for SpamRun {
             rpc_url: row.rpc_url,
             txs_per_duration: row.txs_per_duration,
             duration: row.duration,
-            timeout: row.timeout
+            timeout: row.timeout,
         }
     }
 }
@@ -246,7 +246,7 @@ impl DbOps for SqliteDb {
         rpc_url: &str,
         txs_per_duration: u64,
         duration: u64,
-        timeout: u64
+        timeout: u64,
     ) -> Result<u64> {
         self.execute(
             "INSERT INTO runs (timestamp, tx_count, scenario_name, rpc_url, txs_per_duration, duration, timeout) VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -298,7 +298,7 @@ impl DbOps for SqliteDb {
                     rpc_url: row.get(4)?,
                     txs_per_duration: row.get(5)?,
                     duration: row.get(6)?,
-                    timeout: row.get(7)?
+                    timeout: row.get(7)?,
                 })
             })
             .map_err(|e| ContenderError::with_err(e, "failed to map row"))?;

--- a/crates/sqlite_db/src/lib.rs
+++ b/crates/sqlite_db/src/lib.rs
@@ -15,7 +15,7 @@ use rusqlite::{params, types::FromSql, Row};
 use serde::{Deserialize, Serialize};
 
 /// Increment this whenever making changes to the DB schema.
-pub static DB_VERSION: u64 = 2;
+pub static DB_VERSION: u64 = 3;
 
 #[derive(Clone)]
 pub struct SqliteDb {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Fixes https://github.com/flashbots/contender/issues/197 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

1. Adds the columns `txs_per_duration`, `duration` and `timeout` in the `run` table.
2. Fetches these args from the `spam` command options and add it with the `insert_row` function associated with the runs.
3. Displays the following params in the reports.

<img width="1470" alt="Screenshot 2025-05-02 at 5 34 30 PM" src="https://github.com/user-attachments/assets/eb099703-f758-42c0-a690-d44c2aae8e28" />

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes