### PR TITLE
Build rest of the charts even when Tracing is disabled and heatmap charts fail

### DIFF
--- a/crates/cli/src/commands/report/chart/drawable_charts/heatmap.rs
+++ b/crates/cli/src/commands/report/chart/drawable_charts/heatmap.rs
@@ -51,7 +51,7 @@ impl HeatMapChart {
         }
 
         if updates_per_slot_per_block.is_empty() {
-            return Err("No trace data was collected. If transactions from the specified run landed, your target node may not support geth-style preState traces".into());
+            println!("No trace data was collected. If transactions from the specified run landed, your target node may not support geth-style preState traces");
         }
 
         Ok(Self {
@@ -138,6 +138,15 @@ impl DrawableChart for HeatMapChart {
         let block_nums = self.get_block_numbers();
         let slot_names = self.get_hex_slots();
         let matrix = self.get_matrix();
+
+        if matrix.is_empty() {
+            root.draw(&Text::new(
+                "No trace data was collected",
+                (0, 0),
+                ("sans-serif", 32),
+            ))?;
+            return Ok(());
+        }
 
         let x_size = matrix.len();
         let y_size = matrix[0].len();


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->


<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Solves https://github.com/flashbots/contender/issues/212 
Earlier we'd stop building reports when we encountered an error while building the reports. The first report is a heat map chart of trace data, which when unavailable would halt building rest of the charts.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Earlier we'd check if no trace data was collected, we'd stop. Now if the trace data is empty, we only show that in the report for that particular chart, and build rest of the charts as usual.

<img width="688" alt="Screenshot 2025-05-05 at 10 14 32 AM" src="https://github.com/user-attachments/assets/259404ec-2190-4d6f-9071-de466083f5e9" />



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes