### PR TITLE
fix cargo-workspaces version in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Update crate versions
         run: |
-          cargo workspaces version ${{ steps.version.outputs.version }} --yes --no-git-commit --no-git-push --no-git-tag
+          cargo workspaces version ${{ steps.version.outputs.version }} --yes --no-git-commit
 
       - name: Commit + tag (manual only)
         if: github.event_name == 'workflow_dispatch' && steps.version.outputs.dry_run == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Update crate versions
         run: |
-          cargo workspaces version ${{ steps.version.outputs.version }} --yes --allow-branch '*' --no-git-commit --no-git-push --no-git-tag
+          cargo workspaces version ${{ steps.version.outputs.version }} --yes --no-git-commit --no-git-push --no-git-tag
 
       - name: Commit + tag (manual only)
         if: github.event_name == 'workflow_dispatch' && steps.version.outputs.dry_run == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,6 @@ on:
         required: false
         default: "true"
 
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-
 permissions:
   contents: write  # needed to push tags and create releases
   pull-requests: write
@@ -74,8 +70,8 @@ jobs:
         run: |
           cargo workspaces version ${{ steps.version.outputs.version }} --yes --no-git-commit
 
-      - name: Commit + tag (manual only)
-        if: github.event_name == 'workflow_dispatch' && steps.version.outputs.dry_run == 'false'
+      - name: Commit + tag
+        if: steps.version.outputs.dry_run == 'false'
         run: |
           set -euo pipefail
           VERSION="v${{ steps.version.outputs.version }}"
@@ -88,6 +84,7 @@ jobs:
           git push origin "$BRANCH"
 
       - name: Generate release PR + changelog
+        if: steps.version.outputs.dry_run == 'false'
         run: |
           release-plz release-pr --git-token "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Update crate versions
         run: |
-          cargo workspaces version ${{ steps.version.outputs.version }} --yes --allow-branch '*'
+          cargo workspaces version ${{ steps.version.outputs.version }} --yes --allow-branch '*' --no-git-commit --no-git-push --no-git-tag
 
       - name: Commit + tag (manual only)
         if: github.event_name == 'workflow_dispatch' && steps.version.outputs.dry_run == 'false'


### PR DESCRIPTION
we really should just be using release-plz (but we gotta wait until we have everything ready for crates.io). ChatGPT really screwed up on this one.