### PR TITLE
Composite Scenarios Execution (Part 1) -  Running setup for multiple contracts from a single contender-compose.yml file,

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2193,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "webbrowser",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -2855,7 +2862,7 @@ dependencies = [
  "enr",
  "fnv",
  "futures",
- "hashlink",
+ "hashlink 0.9.1",
  "hex",
  "hkdf",
  "lazy_static",
@@ -3730,6 +3737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -10193,7 +10209,7 @@ dependencies = [
  "bitflags 2.9.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -12811,6 +12827,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b783b2c2789414f8bb84ca3318fc9c2d7e7be1c22907d37839a58dedb369d3"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/contender-compose.yml
+++ b/contender-compose.yml
@@ -1,0 +1,23 @@
+setup:
+  simpler:
+    testfile: ./scenarios/simpler.toml
+    min_balance: 12.1
+
+  uniV2:
+    testfile: ./scenarios/uniV2.toml
+    rpc_url: http://localhost:8545 # Optional
+    min_balance: "11"
+    env:
+      - Key1=Valu1
+      - Key2=Valu2
+    private_keys: # Optional
+      - 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+      - 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+    tx_type: eip1559  # Optional
+
+  uniV3:
+    testfile: ./scenarios/simple.toml
+    rpc_url:  http://localhost:8545 # Optional
+    min_balance: 0.01  # Optional
+    tx_type: eip1559  # Optional
+

--- a/contender-compose.yml
+++ b/contender-compose.yml
@@ -10,7 +10,7 @@ setup:
     env:
       - Key1=Valu1
       - Key2=Valu2
-    private_keys: # Optional
+    private_keys: # Optional (these Private keys are from Anvil)
       - 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
       - 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
     tx_type: eip1559  # Optional

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 webbrowser = { workspace = true }
+yaml-rust2 = "0.10.2"
 
 [dev-dependencies]
 tempfile = "3.15.0"

--- a/crates/cli/src/commands/composite.rs
+++ b/crates/cli/src/commands/composite.rs
@@ -1,0 +1,467 @@
+use std::{error::Error, fs, future::Future, io::Read, str::FromStr, vec};
+
+use alloy::rpc;
+use contender_core::generator::RandSeed;
+use futures::future::join_all;
+use tracing::info;
+use tracing_subscriber::fmt::format;
+use yaml_rust2::{Yaml, YamlLoader};
+
+use crate::{commands::common::cli_env_vars_parser, util::EngineParams};
+
+use super::{common::AuthCliArgs, setup, SetupCliArgs, SetupCommandArgs};
+
+#[derive(Debug, clap::Args)]
+pub struct CompositeScenarioArgs {
+    pub filename: Option<String>,
+}
+
+pub async fn composite(
+    db: &(impl contender_core::db::DbOps + Clone + Send + Sync + 'static),
+    args: CompositeScenarioArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Read testfile
+
+    let compose_file_name = match args.filename {
+        Some(filepath) => filepath,
+        None => String::from("./contender-compose.yml"),
+    };
+
+    println!("Compose file {:?}", &compose_file_name);
+
+    let scenarios = get_setup_from_compose_file(compose_file_name)?;
+
+    for scenario in scenarios {
+        info!("================================================================================================= Setting up contract for: {} =================================================================================================", scenario.name);
+        setup(db, scenario.config).await?;
+    }
+
+    Ok(())
+}
+
+pub struct ComposeFileScenario {
+    pub name: String,
+    pub config: SetupCommandArgs,
+}
+
+fn get_setup_from_compose_file(
+    compose_file_path: String,
+) -> Result<Vec<ComposeFileScenario>, Box<dyn Error>> {
+    // Read file
+    let file_contents = fs::read(&compose_file_path)
+        .map_err(|_e| format!("Can't read the file on path {}", &compose_file_path))?;
+
+    let yaml_file_contents = String::from_utf8_lossy(&file_contents).to_string();
+
+    let compose_file_contents =
+        YamlLoader::load_from_str(&yaml_file_contents).map_err(|_e| "Yaml File failed to parse")?;
+
+    if compose_file_contents.is_empty() {
+        return Err("Compose file is empty".into());
+    }
+    let contracts_list = &compose_file_contents[0]["setup"];
+
+    let mut setup_scenarios = vec![];
+
+    let contracts_hash = contracts_list
+        .as_hash()
+        .ok_or_else(|| "Setup section is not an object".to_string())?;
+
+    for (scenario_name, setup_command_params) in contracts_hash.into_iter() {
+        let scenario_object = setup_command_params
+            .clone()
+            .into_hash()
+            .ok_or(format!("Malformed scenario {:?}", setup_command_params))?;
+
+        let testfile = String::from(
+            setup_command_params["testfile"]
+                .as_str()
+                .ok_or_else(|| "Missing or invalid value for 'testfile'".to_string())?,
+        );
+
+        let rpc_url = match scenario_object.get(&Yaml::String("rpc_url".into())) {
+            Some(rpc_url_value) => {
+                if let Some(url) = rpc_url_value.as_str() {
+                    String::from(url)
+                } else {
+                    return Err("Invalid type value for 'rpc_url'".into());
+                }
+            }
+            None => String::from("http://localhost:8545"),
+        };
+
+        let min_balance = match scenario_object.get(&Yaml::String("min_balance".into())) {
+            Some(min_balance_value) => {
+                // check proper type
+                match min_balance_value {
+                    Yaml::Real(float_str) => Ok(float_str.clone()),
+                    Yaml::Integer(int_val) => Ok(int_val.to_string()),
+                    Yaml::String(str_val) => {
+                        // Try to parse the string as a number to validate it
+                        if str_val.parse::<f64>().is_ok() {
+                            Ok(str_val.clone())
+                        } else {
+                            Err(format!("Invalid min_balance string value: {:?}", str_val))
+                        }
+                    }
+                    _ => Err(format!("Invalid min_balance type: {:?}", min_balance_value)),
+                }
+            }
+            None => Ok("0.01".to_string()),
+        }?;
+
+        let env_variables = match scenario_object.get(&Yaml::String("env".into())) {
+            Some(value) => {
+                match value {
+                    Yaml::Array(env_vars) => {
+                        let mut temp_env_variables = vec![];
+                        for item in env_vars {
+                            if let Some(env_value_pair) = item.as_str() {
+                                temp_env_variables.push(cli_env_vars_parser(env_value_pair)?);
+                            }
+                        }
+                        Ok(Some(temp_env_variables))
+                    },
+                    _ => Err(format!("Invalid env_value type: {:?}", &value)),
+                }
+            },
+            None => Ok(None)
+        }?;
+
+        let private_keys = match scenario_object.get(&Yaml::String("private_keys".into())) {
+            Some(value) => {
+                match value {
+                    Yaml::Array(priv_keys) => {
+                        let mut temp_private_keys = vec![];
+                        for item in priv_keys {
+                            if let Some(p_key) = item.as_str() {
+                                temp_private_keys.push(p_key.to_string());
+                            }
+                        }
+                        Ok(Some(temp_private_keys))
+                    },
+                    _ => Err(format!("Invalid env_value type: {:?}", &value)),
+                }
+            },
+            None => Ok(None)
+        }?;
+
+
+        let tx_type = match scenario_object.get(&Yaml::String("tx_type".into())) {
+            Some(value) => {
+                match value {
+                    Yaml::String(tx_type_string) => {
+                        match tx_type_string.as_str() {
+                            "legacy" => Ok(alloy::consensus::TxType::Legacy),
+                            "eip1559" => Ok(alloy::consensus::TxType::Eip1559),
+                            _ => Err(format!("Invalid Value for 'tx_type' = {}", tx_type_string.as_str()))
+                        }
+                    },
+                    _ => Err(format!("Invalid type value for 'tx_type' = {:?}", value))
+                }
+            },
+            None => Ok(alloy::consensus::TxType::Eip1559 )
+        }?;
+
+        setup_scenarios.push(ComposeFileScenario {
+            name: scenario_name.as_str().unwrap().to_owned(),
+            config: SetupCommandArgs {
+                testfile,
+                rpc_url,
+                min_balance,
+                env: env_variables,
+                tx_type,
+                private_keys,
+
+                // TODO: Hardcoded parameters for now, need more understanding on where to get these from
+                seed: RandSeed::new(),
+                engine_params: EngineParams {
+                    engine_provider: None,
+                    call_fcu: false,
+                },
+            },
+        });
+    }
+    Ok(setup_scenarios)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_temp_yaml_file(content: &str) -> Result<NamedTempFile, Box<dyn Error>> {
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(content.as_bytes())?;
+        temp_file.flush()?;
+        Ok(temp_file)
+    }
+
+    #[test]
+    fn non_existent_compose_file() -> Result<(), Box<dyn Error>> {
+        let scenarios = get_setup_from_compose_file("./non-existent-scene.yml".to_string());
+        assert_eq!(
+            scenarios.err().unwrap().to_string(),
+            "Can't read the file on path ./non-existent-scene.yml"
+        );
+        Ok(())
+    }
+
+    // Done
+    #[test]
+    fn test_basic_valid_yaml() -> Result<(), Box<dyn Error>> {
+        let yaml_content = r#"
+setup:
+  scenario1:
+    testfile: "./tests/test1.js"
+    rpc_url: "http://localhost:9545"
+    min_balance: '5'
+    tx_type: "eip1559"
+    private_keys:
+      - "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+      - "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    env:
+      - "KEY1=value1"
+      - "KEY2=value2"
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content)?;
+        let scenarios =
+            get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string())?;
+
+        assert_eq!(scenarios.len(), 1);
+        assert_eq!(scenarios[0].name, "scenario1");
+        assert_eq!(scenarios[0].config.testfile, "./tests/test1.js");
+        assert_eq!(scenarios[0].config.rpc_url, "http://localhost:9545");
+        assert_eq!(scenarios[0].config.min_balance, "5");
+        assert_eq!(
+            scenarios[0].config.tx_type,
+            alloy::consensus::TxType::Eip1559
+        );
+
+        let private_keys = scenarios[0].config.private_keys.as_ref().unwrap();
+        assert_eq!(private_keys.len(), 2);
+        assert_eq!(
+            private_keys[0],
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        );
+
+        let env_vars = scenarios[0].config.env.as_ref().unwrap();
+        assert_eq!(env_vars.len(), 2);
+        // Assuming cli_env_vars_parser returns a tuple of (key, value)
+        assert_eq!(env_vars[0].0, "KEY1");
+        assert_eq!(env_vars[0].1, "value1");
+
+        Ok(())
+    }
+
+    // Done
+    #[test]
+    fn test_missing_testfile() {
+        let yaml_content = r#"
+setup:
+  missing_testfile:
+    rpc_url: "http://localhost:8545"
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content).unwrap();
+        let result = get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string());
+
+        assert!(result.is_err());
+        match result {
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Missing or invalid value for 'testfile'")),
+            _ => panic!("Expected an error for missing testfile"),
+        }
+    }
+
+    // Done
+    #[test]
+    fn test_default_values() -> Result<(), Box<dyn Error>> {
+        let yaml_content = r#"
+setup:
+  scenario1:
+    testfile: "./tests/test1.js"
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content)?;
+        let scenarios =
+            get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string())?;
+
+        assert_eq!(scenarios.len(), 1);
+        assert_eq!(scenarios[0].name, "scenario1");
+        assert_eq!(scenarios[0].config.testfile, "./tests/test1.js");
+        assert_eq!(scenarios[0].config.rpc_url, "http://localhost:8545");
+        assert_eq!(scenarios[0].config.min_balance, "0.01"); // Default value
+        assert_eq!(scenarios[0].config.tx_type, alloy::consensus::TxType::Eip1559);
+        assert_eq!(scenarios[0].config.env, None);
+        assert_eq!(scenarios[0].config.private_keys, None);
+        Ok(())
+    }
+
+    // Done
+    #[test]
+    fn test_legacy_tx_type() -> Result<(), Box<dyn Error>> {
+        let yaml_content = r#"
+setup:
+  legacy_scenario:
+    testfile: "./tests/legacy.js"
+    tx_type: "legacy"
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content)?;
+        let scenarios =
+            get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string())?;
+
+        assert_eq!(scenarios.len(), 1);
+        assert_eq!(
+            scenarios[0].config.tx_type,
+            alloy::consensus::TxType::Legacy
+        );
+
+        Ok(())
+    }
+
+        // Done
+    #[test]
+    fn test_eip1559_tx_type() -> Result<(), Box<dyn Error>> {
+        let yaml_content = r#"
+setup:
+  legacy_scenario:
+    testfile: "./tests/legacy.js"
+    tx_type: eip1559
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content)?;
+        let scenarios =
+            get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string())?;
+
+        assert_eq!(
+            scenarios[0].config.tx_type,
+            alloy::consensus::TxType::Eip1559
+        );
+
+        Ok(())
+    }
+
+    // Done
+    #[test]
+    fn test_invalid_tx_type() {
+        let yaml_content = r#"
+setup:
+  invalid_scenario:
+    testfile: "./tests/invalid.js"
+    tx_type: "invalid_type"
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content).unwrap();
+        let result = get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string());
+
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().to_string(), "Invalid Value for 'tx_type' = invalid_type".to_string())
+    }
+
+    // Done
+    #[test]
+    fn test_valid_env_variables() -> Result<(), Box<dyn std::error::Error>>{
+                let yaml_content = r#"
+setup:
+  invalid_scenario:
+    testfile: "./tests/some.toml"
+    env:
+        - KEY1=VALUE1
+        - KEY2=VALUE2
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content).unwrap();
+        let result = get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string())?;
+
+        assert_eq!(result[0].config.env.as_ref().unwrap()[0].0.to_string(), "KEY1".to_string());
+        assert_eq!(result[0].config.env.as_ref().unwrap()[0].1, "VALUE1".to_string());
+        assert_eq!(result[0].config.env.as_ref().unwrap()[1].0, "KEY2".to_string());
+        assert_eq!(result[0].config.env.as_ref().unwrap()[1].1, "VALUE2".to_string());
+        
+        Ok(())
+    }
+
+
+
+    #[test]
+    fn test_non_existent_file() -> Result<(), Box<dyn Error>> {
+        let result = get_setup_from_compose_file("non_existent_file.yaml".to_string());
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_malformed_yaml() -> Result<(), Box<dyn Error>> {
+        let yaml_content = r#"
+setup:
+  malformed:
+    testfile: "test.js"
+    min_balance: ]
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content).unwrap();
+        let result = get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string());
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_yaml() {
+        let yaml_content = "";
+        let temp_file = create_temp_yaml_file(yaml_content).unwrap();
+        let result = get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string());
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_numeric_values_for_min_balance() -> Result<(), Box<dyn Error>> {
+        let yaml_content = r#"
+setup:
+  numeric_scenario:
+    testfile: "./tests/numeric.js"
+    min_balance: "5"
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content)?;
+        let scenarios =
+            get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string())?;
+
+        assert_eq!(scenarios[0].config.min_balance, "5");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_private_keys_and_envs() -> Result<(), Box<dyn Error>> {
+        let yaml_content = r#"
+setup:
+  empty_arrays:
+    testfile: "./tests/empty.js"
+    private_keys: []
+    env: []
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content)?;
+        let scenarios =
+            get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string())?;
+
+        let private_keys = scenarios[0].config.private_keys.as_ref().unwrap();
+        assert_eq!(private_keys.len(), 0);
+
+        let env_vars = scenarios[0].config.env.as_ref().unwrap();
+        assert_eq!(env_vars.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_no_setup_section() {
+        let yaml_content = r#"
+version: '3'
+services:
+  web:
+    image: nginx
+"#;
+        let temp_file = create_temp_yaml_file(yaml_content).unwrap();
+        let result = get_setup_from_compose_file(temp_file.path().to_string_lossy().to_string());
+
+        assert!(result.is_err() || result.unwrap().is_empty());
+    }
+}

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -10,7 +10,7 @@ use crate::util::TxTypeCli;
 
 #[derive(Debug, Subcommand)]
 pub enum ContenderSubcommand {
-    #[command(name = "compose", about = "Composite scenario")]
+    #[command(name = "compose", about = "Composite scenario execution, setup and spam multiple contracts from a single YML file.")]
     Composite {
         #[arg(
             short,

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -10,6 +10,17 @@ use crate::util::TxTypeCli;
 
 #[derive(Debug, Subcommand)]
 pub enum ContenderSubcommand {
+    #[command(name = "compose", about = "Composite scenario")]
+    Composite {
+        #[arg(
+            short,
+            long,
+            long_help = "File path for composite scenario file",
+            default_value = "./contender-compose.yml"
+        )]
+        filename: Option<String>,
+    },
+
     #[command(name = "admin", about = "Admin commands")]
     Admin {
         #[command(subcommand)]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod common;
+pub mod composite;
 mod contender_subcommand;
 pub mod db;
 mod report;
@@ -10,6 +11,7 @@ mod spamd;
 
 use clap::Parser;
 
+pub use composite::composite;
 pub use contender_subcommand::{ContenderSubcommand, DbCommand};
 pub use report::report;
 pub use run::{run, RunCommandArgs};

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,6 +6,7 @@ use alloy::hex;
 use commands::{
     admin::handle_admin_command,
     common::{ScenarioSendTxsCliArgs, SendSpamCliArgs},
+    composite::CompositeScenarioArgs,
     db::{drop_db, export_db, import_db, reset_db},
     ContenderCli, ContenderSubcommand, DbCommand, RunCommandArgs, SetupCliArgs, SetupCommandArgs,
     SpamCliArgs, SpamCommandArgs,
@@ -89,6 +90,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             DbCommand::Export { out_path } => export_db(&db_path, out_path).await?,
             DbCommand::Import { src_path } => import_db(src_path, &db_path).await?,
         },
+        ContenderSubcommand::Composite { filename } => {
+            commands::composite(&db, CompositeScenarioArgs { filename }).await?;
+        }
 
         ContenderSubcommand::Setup {
             args:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This PR is step 1 for composite scenario execution, as suggested in https://github.com/flashbots/contender/issues/145

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adding a new `compose` command, similar to `docker compose`
```
Composite scenario execution, setup and spam multiple contracts from a single YML file.

Usage: contender compose [OPTIONS]

Options:
  -f, --filename <FILENAME>
          File path for composite scenario file
          
          [default: ./contender-compose.yml]
 ```

Currently this only supports `setup` command, it parses a `contender-compose.yml` file and deploys multiple contracts from a single `contender compose` command.

The next step would be to include the `spam` from this file. Before implementing that, I want to know if all these spams are going to be run parallely and fall under a single run ID, or be separate runs one after the other.

Also, I feel it would be better to have all the logic for the `compose` file to be a separate crate of its own, similar to `testfile`. Let me know your thoughts, and any feedback on how to improve/move forward with this.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes