### PR TITLE
take units with eth value in --min-balance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         cache-on-failure: true
     - name: Install deps
-      run: sudo apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
+      run: sudo apt-get update && apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
     - name: Build
       run: cargo build --verbose --workspace
 
@@ -50,6 +50,6 @@ jobs:
       with:
         cache-on-failure: true
     - name: Install deps
-      run: sudo apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
+      run: sudo apt-get update && apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
     - name: Run tests
       run: cargo test --verbose --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         cache-on-failure: true
     - name: Install deps
-      run: sudo apt-get update && apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
+      run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
     - name: Build
       run: cargo build --verbose --workspace
 
@@ -50,6 +50,6 @@ jobs:
       with:
         cache-on-failure: true
     - name: Install deps
-      run: sudo apt-get update && apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
+      run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev fontconfig libfontconfig1-dev libfontconfig
     - name: Run tests
       run: cargo test --verbose --workspace

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -1,10 +1,11 @@
 //! This file contains type definition for CLI arguments.
 
-use std::sync::Arc;
-
-use crate::util::{EngineParams, TxTypeCli};
+use alloy::primitives::utils::parse_units;
+use alloy::primitives::U256;
 
 use super::EngineArgs;
+use crate::util::{EngineParams, TxTypeCli};
+use std::sync::Arc;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct ScenarioSendTxsCliArgs {
@@ -41,9 +42,10 @@ May be specified multiple times."
     #[arg(
         long,
         long_help = "The minimum balance to check for each private key in decimal-ETH format (`--min-balance 1.5` means 1.5 * 1e18 wei).",
-        default_value = "0.01"
+        default_value = "0.01 ether",
+        value_parser = parse_amount,
     )]
-    pub min_balance: String,
+    pub min_balance: U256,
 
     /// Transaction type
     #[arg(
@@ -158,7 +160,7 @@ Requires --priv-key to be set for each 'from' address in the given testfile.",
         default_value = "1",
         long_help = "Duration of the spamming run in seconds or blocks, depending on whether --txs-per-second or --txs-per-block is set."
     )]
-    pub duration: u64,
+    pub duration: u64, // TODO: make a new enum to represent seconds or blocks
 
     /// The time to wait for pending transactions to land, in seconds.
     #[arg(
@@ -194,6 +196,21 @@ pub fn cli_env_vars_parser(s: &str) -> Result<(String, String), String> {
         s[..equal_sign_index].to_string(),
         s[equal_sign_index + 1..].to_string(),
     ))
+}
+
+pub fn parse_amount(input: &str) -> Result<U256, String> {
+    let input = input.trim().to_lowercase();
+    let (num_str, unit) = input.trim().split_at(
+        input
+            .find(|c: char| !c.is_numeric() && c != '.')
+            .ok_or("Missing unit in amount")?,
+    );
+    let unit = unit.trim();
+    let value: U256 = parse_units(num_str, unit)
+        .map_err(|e| format!("Failed to parse units: {e}"))?
+        .into();
+
+    Ok(value)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloy::{
     consensus::TxType,
     network::AnyNetwork,
-    primitives::utils::{format_ether, parse_ether},
+    primitives::{utils::format_ether, U256},
     providers::{DynProvider, Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
     transports::http::reqwest::Url,
@@ -71,8 +71,6 @@ pub async fn setup(
         }
     }
     testconfig.env = Some(env_variables.clone());
-
-    let min_balance = parse_ether(&min_balance)?;
 
     let user_signers = private_keys
         .as_ref()
@@ -290,7 +288,7 @@ pub struct SetupCommandArgs {
     pub testfile: String,
     pub rpc_url: String,
     pub private_keys: Option<Vec<String>>,
-    pub min_balance: String,
+    pub min_balance: U256,
     pub seed: RandSeed,
     pub tx_type: TxType,
     pub engine_params: EngineParams,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

units were ambiguous; someone might enter a wei amount by accident, and it would be interpreted as an ether amount.

## Solution

- parse with alloy's [`parse_units`](https://github.com/alloy-rs/core/blob/main/crates/primitives/src/utils/units.rs#L47)
- use `value_parser` macro (need to do this with more params; we have a lot of duplication because of not using this) 

examples:

```sh
cargo run -- setup --min-balance 1eth
cargo run -- setup --min-balance "0.15 ether"
cargo run -- setup --min-balance 500000gwei
```

Alloy's [Unit](https://github.com/alloy-rs/core/blob/main/crates/primitives/src/utils/units.rs#L440-L492) defines more denominations.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes