### PR TITLE
Release/v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contender_bundle_provider"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "serde",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "contender_cli"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "ansi_term",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "contender_engine_provider"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "contender_core",

--- a/crates/bundle_provider/CHANGELOG.md
+++ b/crates/bundle_provider/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/flashbots/contender/releases/tag/contender_bundle_provider-v0.1.6) - 2025-05-14
+## [0.2.0](https://github.com/flashbots/contender/releases/tag/contender_bundle_provider-v0.2.0) - 2025-05-14
 
 ### Other
 

--- a/crates/bundle_provider/Cargo.toml
+++ b/crates/bundle_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_bundle_provider"
-version = "0.1.6"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/flashbots/contender/releases/tag/contender_cli-v0.1.6) - 2025-05-14
+## [0.2.0](https://github.com/flashbots/contender/releases/tag/contender_cli-v0.2.0) - 2025-05-14
 
 ### Added
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_cli"
-version = "0.1.6"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/flashbots/contender/releases/tag/contender_core-v0.1.6) - 2025-05-14
+## [0.2.0](https://github.com/flashbots/contender/releases/tag/contender_core-v0.2.0) - 2025-05-14
 
 ### Added
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_core"
-version = "0.1.6"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/engine_provider/CHANGELOG.md
+++ b/crates/engine_provider/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/flashbots/contender/releases/tag/contender_engine_provider-v0.1.6) - 2025-05-14
+## [0.2.0](https://github.com/flashbots/contender/releases/tag/contender_engine_provider-v0.2.0) - 2025-05-14
 
 ### Other
 

--- a/crates/engine_provider/Cargo.toml
+++ b/crates/engine_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_engine_provider"
-version = "0.1.6"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/report/CHANGELOG.md
+++ b/crates/report/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/flashbots/contender/releases/tag/contender_report-v0.1.0) - 2025-05-14
+
+### Added
+
+- moved `report` from cli to its own crate
+  - can now be used as a lib by other projects

--- a/crates/report/CHANGELOG.md
+++ b/crates/report/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0](https://github.com/flashbots/contender/releases/tag/contender_report-v0.1.0) - 2025-05-14
+## [0.2.0](https://github.com/flashbots/contender/releases/tag/contender_report-v0.2.0) - 2025-05-14
 
 ### Added
 

--- a/crates/report/Cargo.toml
+++ b/crates/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_report"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/sqlite_db/CHANGELOG.md
+++ b/crates/sqlite_db/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/flashbots/contender/releases/tag/contender_sqlite-v0.1.6) - 2025-05-14
+## [0.2.0](https://github.com/flashbots/contender/releases/tag/contender_sqlite-v0.2.0) - 2025-05-14
 
 ### Other
 

--- a/crates/sqlite_db/Cargo.toml
+++ b/crates/sqlite_db/Cargo.toml
@@ -7,7 +7,7 @@ name = "contender_sqlite"
 description = "SQLite database for contender"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.1.6"
+version = "0.2.0"
 
 [dependencies]
 alloy = {workspace = true}

--- a/crates/testfile/CHANGELOG.md
+++ b/crates/testfile/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/flashbots/contender/releases/tag/contender_testfile-v0.1.6) - 2025-05-14
+## [0.2.0](https://github.com/flashbots/contender/releases/tag/contender_testfile-v0.2.0) - 2025-05-14
 
 ### Fixed
 

--- a/crates/testfile/Cargo.toml
+++ b/crates/testfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_testfile"
-version = "0.1.6"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
#264 introduced many breaking changes to `contender_core`.

`contender_report` is also a new crate.