### PR TITLE
fix setup bug (must call contract deploy in load_txs callback)

### DIFF
--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -242,6 +242,7 @@ pub async fn setup(
         let is_done = is_done.clone();
         tokio::task::spawn(async move {
             let str_err = |e| format!("Error: {e}");
+            info!("Deploying contracts...");
             scenario.deploy_contracts().await.map_err(str_err)?;
             timekeeper_handle.abort();
             info!("Finished deploying contracts. Running setup txs...");

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -473,7 +473,7 @@ where
         .await?;
 
         err_recv.close();
-        while let Some(err) = err_recv.recv().await {
+        if let Some(err) = err_recv.recv().await {
             return Err(err);
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

recent changes broke setup: when deploying a contract that depends on a previous contract deployment, it would fail saying "address for named transaction not found in DB"

## Solution

deployments must happen in the `load_txs` callback, otherwise the subsequent items will not have the contracts in the DB required to render the next step

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes