### PR TITLE
fix error-handling bugs

### DIFF
--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -282,23 +282,8 @@ impl SpamCommandArgs {
         .await?;
 
         if self.scenario.is_builtin() {
-            let scenario = &mut scenario;
-            let setup_res = tokio::select! {
-                res = async move {
-                    let str_err = |e| format!("Setup error: {e}");
-                    scenario.deploy_contracts().await.map_err(str_err)?;
-                    scenario.run_setup().await.map_err(str_err)?;
-                    Ok::<(), String>(())
-                } => {
-                    res
-                }
-            };
-            if let Err(e) = setup_res {
-                return Err(ContenderError::SpamError(
-                    "Builtin scenario setup failed.",
-                    Some(e),
-                ));
-            }
+            scenario.deploy_contracts().await?;
+            scenario.run_setup().await?;
         }
         done_fcu.store(true, std::sync::atomic::Ordering::SeqCst);
         if let Some(handle) = fcu_handle {

--- a/crates/core/src/generator/trait.rs
+++ b/crates/core/src/generator/trait.rs
@@ -285,7 +285,7 @@ where
                     if let Some(handle) = handle {
                         handle.await.map_err(|e| {
                             ContenderError::with_err(e, "join error; callback crashed")
-                        })?;
+                        })??;
                     }
                     txs.push(tx.into());
                 }
@@ -312,7 +312,7 @@ where
                     if let Some(handle) = handle {
                         handle.await.map_err(|e| {
                             ContenderError::with_err(e, "join error; callback crashed")
-                        })?;
+                        })??;
                     }
                     txs.push(tx.into());
                 }
@@ -394,7 +394,7 @@ where
                                 if let Some(handle) = handle {
                                     handle.await.map_err(|e| {
                                         ContenderError::with_err(e, "error from callback")
-                                    })?;
+                                    })??;
                                 }
                                 txs.push(tx.into());
                             }
@@ -405,7 +405,7 @@ where
                                     if let Some(handle) = handle {
                                         handle.await.map_err(|e| {
                                             ContenderError::with_err(e, "error from callback")
-                                        })?;
+                                        })??;
                                     }
                                     bundle_txs.push(txr);
                                 }

--- a/crates/core/src/generator/types.rs
+++ b/crates/core/src/generator/types.rs
@@ -111,7 +111,7 @@ pub struct Plan {
     pub spam_steps: Vec<ExecutionRequest>,
 }
 
-pub type CallbackResult = crate::Result<Option<JoinHandle<()>>>;
+pub type CallbackResult = crate::Result<Option<JoinHandle<crate::Result<()>>>>;
 
 /// Defines the type of plan to be executed.
 pub enum PlanType<F: Fn(NamedTxRequest) -> CallbackResult> {

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -1,5 +1,8 @@
 use super::tx_actor::{CacheTx, TxActorHandle};
-use crate::generator::{types::AnyProvider, NamedTxRequest};
+use crate::{
+    error::ContenderError,
+    generator::{types::AnyProvider, NamedTxRequest},
+};
 use alloy::providers::PendingTransactionConfig;
 use contender_engine_provider::{AdvanceChain, DEFAULT_BLOCK_TIME};
 use std::{collections::HashMap, sync::Arc};
@@ -19,6 +22,12 @@ where
         tx_handlers: Option<HashMap<String, Arc<TxActorHandle>>>,
     ) -> Option<JoinHandle<crate::Result<()>>>;
 }
+
+pub trait OnBatchSent {
+    fn on_batch_sent(&self) -> Option<JoinHandle<crate::Result<()>>>;
+}
+
+pub trait SpamCallback: OnTxSent + OnBatchSent + Send + Sync {}
 
 #[derive(Clone, Debug)]
 pub struct RuntimeTxInfo {
@@ -77,12 +86,6 @@ impl Default for RuntimeTxInfo {
         }
     }
 }
-
-pub trait OnBatchSent {
-    fn on_batch_sent(&self) -> Option<JoinHandle<Result<(), String>>>;
-}
-
-pub trait SpamCallback: OnTxSent + OnBatchSent + Send + Sync {}
 
 impl<T: OnTxSent + OnBatchSent + Sized + Send + Sync> SpamCallback for T {}
 
@@ -155,7 +158,7 @@ impl OnTxSent for LogCallback {
 }
 
 impl OnBatchSent for LogCallback {
-    fn on_batch_sent(&self) -> Option<JoinHandle<Result<(), String>>> {
+    fn on_batch_sent(&self) -> Option<JoinHandle<crate::Result<()>>> {
         debug!("on_batch_sent called");
         if !self.send_fcu {
             // maybe do something metrics-related here
@@ -164,8 +167,10 @@ impl OnBatchSent for LogCallback {
         if let Some(provider) = &self.auth_provider {
             let provider = provider.clone();
             return Some(tokio::task::spawn(async move {
-                let res = provider.advance_chain(DEFAULT_BLOCK_TIME).await;
-                res.map_err(|e| e.to_string())
+                Ok(provider
+                    .advance_chain(DEFAULT_BLOCK_TIME)
+                    .await
+                    .map_err(|e| ContenderError::from(e))?)
             }));
         }
         None
@@ -173,7 +178,7 @@ impl OnBatchSent for LogCallback {
 }
 
 impl OnBatchSent for NilCallback {
-    fn on_batch_sent(&self) -> Option<JoinHandle<Result<(), String>>> {
+    fn on_batch_sent(&self) -> Option<JoinHandle<crate::Result<()>>> {
         // do nothing
         None
     }

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -167,10 +167,10 @@ impl OnBatchSent for LogCallback {
         if let Some(provider) = &self.auth_provider {
             let provider = provider.clone();
             return Some(tokio::task::spawn(async move {
-                Ok(provider
+                provider
                     .advance_chain(DEFAULT_BLOCK_TIME)
                     .await
-                    .map_err(|e| ContenderError::from(e))?)
+                    .map_err(ContenderError::from)
             }));
         }
         None

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -17,7 +17,7 @@ where
         req: &NamedTxRequest,
         extra: RuntimeTxInfo,
         tx_handlers: Option<HashMap<String, Arc<TxActorHandle>>>,
-    ) -> Option<JoinHandle<()>>;
+    ) -> Option<JoinHandle<crate::Result<()>>>;
 }
 
 #[derive(Clone, Debug)]
@@ -119,7 +119,7 @@ impl OnTxSent for NilCallback {
         _req: &NamedTxRequest,
         _extra: RuntimeTxInfo,
         _tx_handlers: Option<HashMap<String, Arc<TxActorHandle>>>,
-    ) -> Option<JoinHandle<()>> {
+    ) -> Option<JoinHandle<crate::Result<()>>> {
         // do nothing
         None
     }
@@ -132,7 +132,7 @@ impl OnTxSent for LogCallback {
         _req: &NamedTxRequest,
         extra: RuntimeTxInfo,
         tx_actors: Option<HashMap<String, Arc<TxActorHandle>>>,
-    ) -> Option<JoinHandle<()>> {
+    ) -> Option<JoinHandle<crate::Result<()>>> {
         let cancel_token = self.cancel_token.clone();
         let handle = tokio::task::spawn(async move {
             if let Some(tx_actors) = tx_actors {
@@ -148,6 +148,7 @@ impl OnTxSent for LogCallback {
                     _ = tx_actor.cache_run_tx(tx) => {}
                 };
             }
+            Ok(())
         });
         Some(handle)
     }

--- a/crates/core/src/spammer/util.rs
+++ b/crates/core/src/spammer/util.rs
@@ -33,7 +33,7 @@ pub mod test {
     }
 
     impl OnBatchSent for MockCallback {
-        fn on_batch_sent(&self) -> Option<JoinHandle<Result<(), String>>> {
+        fn on_batch_sent(&self) -> Option<JoinHandle<crate::Result<()>>> {
             info!("MockCallback::on_batch_sent");
             None
         }

--- a/crates/core/src/spammer/util.rs
+++ b/crates/core/src/spammer/util.rs
@@ -26,7 +26,7 @@ pub mod test {
             _req: &NamedTxRequest,
             _extra: RuntimeTxInfo,
             _tx_handler: Option<HashMap<String, Arc<TxActorHandle>>>,
-        ) -> Option<JoinHandle<()>> {
+        ) -> Option<JoinHandle<crate::Result<()>>> {
             info!("MockCallback::on_tx_sent: tx_hash={}", _tx_res.tx_hash());
             None
         }

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -425,10 +425,6 @@ where
             .await
             .map_err(|e| ContenderError::with_err(e, "failed to get chain id"))?;
 
-        // capture errors from inside the callback
-        let (err_send, mut err_recv) = tokio::sync::mpsc::channel::<ContenderError>(100);
-        let error_sender = Arc::new(err_send);
-
         // we do everything in the callback so no need to actually capture the returned txs
         // we have to do this to populate the database with new named transaction after each deployment
         self.load_txs(PlanType::Create(|tx_req| {
@@ -448,30 +444,18 @@ where
                 .unwrap_or_else(|| panic!("couldn't find wallet for 'from' address {from}"))
                 .to_owned();
             let db = self.db.clone();
-            let error_sender = error_sender.clone();
 
             let handle = tokio::task::spawn(async move {
-                let res = Self::deploy_contract(
+                Self::deploy_contract(
                     &db, &tx_req, gas_price, chain_id, tx_type, &rpc_url, &wallet,
                 )
-                .await;
-
-                if let Err(e) = res {
-                    error_sender
-                        .send(e)
-                        .await
-                        .expect("failed to send error from task");
-                }
+                .await?;
+                Ok(())
             });
 
             Ok(Some(handle))
         }))
         .await?;
-
-        err_recv.close();
-        if let Some(err) = err_recv.recv().await {
-            return Err(err);
-        }
 
         self.sync_nonces().await?;
 
@@ -582,18 +566,20 @@ where
                     .or(tx_req.kind.as_deref())
                     .unwrap_or("")
                     .to_string();
-                let gas_price = wallet.get_gas_price().await.unwrap_or_else(|_| {
-                    panic!("failed to get gas price for setup step '{tx_label}'")
-                });
+                let gas_price = wallet.get_gas_price().await.map_err(|e| {
+                    warn!("failed to get gas price for setup step '{tx_label}'");
+                    ContenderError::with_err(e, "failed to get gas price")
+                })?;
                 let gas_limit = if let Some(gas) = tx_req.tx.gas {
                     gas
                 } else {
                     wallet
                         .estimate_gas(tx_req.tx.to_owned())
                         .await
-                        .unwrap_or_else(|_| {
-                            panic!("failed to estimate gas for setup step '{tx_label}'")
-                        })
+                        .map_err(|e| {
+                            warn!("failed to estimate gas for setup step '{tx_label}'");
+                            ContenderError::with_err(e, "failed to estimate gas")
+                        })?
                 };
                 let mut tx = tx_req.tx;
                 complete_tx_request(
@@ -606,16 +592,16 @@ where
                 );
 
                 // wallet will assign nonce before sending
-                let res = wallet
-                    .send_transaction(tx)
-                    .await
-                    .unwrap_or_else(|_| panic!("failed to send setup tx '{tx_label}'"));
+                let res = wallet.send_transaction(tx).await.map_err(|e| {
+                    warn!("failed to send setup tx '{tx_label}'");
+                    ContenderError::with_err(e, "setup tx failed")
+                })?;
 
                 // get receipt using provider (not wallet) to allow any receipt type (support non-eth chains)
                 let receipt = res
                     .get_receipt()
                     .await
-                    .unwrap_or_else(|_| panic!("failed to get receipt for tx '{tx_label}'"));
+                    .map_err(|e| ContenderError::with_err(e, "failed to get receipt"))?;
 
                 if let Some(name) = tx_req.name {
                     db.insert_named_txs(
@@ -625,9 +611,10 @@ where
                             receipt.contract_address,
                         )],
                         rpc_url.as_str(),
-                    )
-                    .expect("failed to insert tx into db");
+                    )?;
                 }
+
+                Ok(())
             });
             Ok(Some(handle))
         }))

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -1024,8 +1024,7 @@ where
             // wait for the on_batch_sent callback to finish
             if let Some(task) = sent_tx_callback.on_batch_sent() {
                 task.await
-                    .map_err(|e| ContenderError::with_err(e, "on_batch_sent callback failed"))?
-                    .map_err(|e| ContenderError::SpamError("failed to send batch", Some(e)))?;
+                    .map_err(|e| ContenderError::with_err(e, "on_batch_sent callback failed"))??;
             }
 
             info!("[{tick}] executed {num_tasks} spam tasks");

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -449,8 +449,7 @@ where
                 Self::deploy_contract(
                     &db, &tx_req, gas_price, chain_id, tx_type, &rpc_url, &wallet,
                 )
-                .await?;
-                Ok(())
+                .await
             });
 
             Ok(Some(handle))


### PR DESCRIPTION
## Motivation & Solution

- remove/replace over-engineered mpsc channels to pass errors from inside tokio tasks
- replace panics with errors
- return `Result<()>` from `OnTxSent` & `OnBatchSent` callbacks (`JoinHandle`s) for simpler error-handling within callbacks

## BREAKING CHANGES

the return type from `on_tx_sent` and `on_batch_sent` has changed from `Option<JoinHandle<()>>` to `Option<JoinHandle<crate::Result<()>>>`. This will require external callback implementations to modify their signatures, but will also allow them to use `?` syntax to handle errors!

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes