### PR TITLE
fix error-handling in traces & heatmap

### DIFF
--- a/crates/report/src/block_trace.rs
+++ b/crates/report/src/block_trace.rs
@@ -37,6 +37,11 @@ pub async fn get_block_data(
         .cloned()
         .collect();
 
+    if txs.is_empty() {
+        warn!("No landed transactions found. No block data is available.");
+        return Ok(vec![]);
+    }
+
     // find block range of txs
     let (min_block, max_block) = txs.iter().fold((u64::MAX, 0), |(min, max), tx| {
         let bn = tx.block_number.expect("tx has no block number");

--- a/crates/report/src/block_trace.rs
+++ b/crates/report/src/block_trace.rs
@@ -12,7 +12,7 @@ use contender_core::error::ContenderError;
 use contender_core::generator::types::AnyProvider;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TxTraceReceipt {
@@ -121,7 +121,7 @@ pub async fn get_block_traces(
                             e,
                             "debug_traceTransaction failed. Make sure geth-style tracing is enabled on your node.",
                         )
-                    }).unwrap();
+                    })?;
 
                 // receipt might fail if we target a non-ETH chain
                 // so if it does fail, we just ignore it
@@ -132,13 +132,17 @@ pub async fn get_block_traces(
                         sender
                             .send(TxTraceReceipt::new(trace, receipt))
                             .await
-                            .unwrap();
+                            .map_err(|join_err| {
+                                ContenderError::with_err(join_err, "failed to join trace receipt")
+                            })?;
                     } else {
-                        info!("no receipt for tx {tx_hash:?}");
+                        warn!("no receipt for tx {tx_hash:?}");
                     }
                 } else {
-                    info!("ignored receipt for tx {tx_hash:?} (failed to decode)");
+                    warn!("ignored receipt for tx {tx_hash:?} (failed to decode)");
                 }
+
+                Ok::<_, ContenderError>(())
             });
             tx_tasks.push(task);
         }

--- a/crates/report/src/template.html.handlebars
+++ b/crates/report/src/template.html.handlebars
@@ -156,6 +156,12 @@
       width: 100%;
       height: 420px;
     }
+
+    .no-chart {
+      width: 100%;
+      height: 20px;
+      text-align: center;
+    }
   </style>
 
 </head>
@@ -306,6 +312,14 @@
     }
 
     async function renderHeatmap() {
+      // data may be missing if the target node does not support geth-style traces.
+      // if data is missing, skip rendering, replacing the 'heatmap' div with a message
+      if ({{data.chart_data.heatmap.blocks}}.length === 0) {
+        document.getElementById('heatmap').innerHTML = '<p>No data available. Target node may not support geth-style preState traces.</p>';
+        document.getElementById('heatmap').className = 'no-chart';
+        return;
+      }
+
       // Initialize the echarts instance based on the prepared dom
       var chart = echarts.init(document.getElementById('heatmap'));
 

--- a/scenarios/bundles.toml
+++ b/scenarios/bundles.toml
@@ -17,5 +17,5 @@ gas_limit = 70000
 to = "{SpamMe}"
 from_pool = "bluepool"
 signature = "tipCoinbase()"
-value = "10000000000000000"
+value = "100000000000000"
 gas_limit = 42000


### PR DESCRIPTION
## Motivation

traces that weren't appropriate to decode were crashing reports.

## Solution

print a warning instead of panicking when we fail to decode a trace frame

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes