### PR TITLE
prevent chain_id mismatch btwn rpc & builder

### DIFF
--- a/crates/bundle_provider/src/bundle_provider.rs
+++ b/crates/bundle_provider/src/bundle_provider.rs
@@ -17,6 +17,12 @@ pub struct BundleClient {
     client: RootProvider<AnyNetwork>,
 }
 
+impl Provider<AnyNetwork> for BundleClient {
+    fn root(&self) -> &RootProvider<AnyNetwork> {
+        self.client.root()
+    }
+}
+
 impl BundleClient {
     /// Creates a new [`BundleClient`] with the given URL.
     pub fn new(url: impl IntoUrl) -> Result<Self, BundleProviderError> {

--- a/crates/core/src/generator/trait.rs
+++ b/crates/core/src/generator/trait.rs
@@ -176,6 +176,11 @@ where
         })
     }
 
+    /// Converts a `FunctionCallDefinition` to a `FunctionCallDefinitionStrict`, replacing
+    /// `{_sender}` with the `from` address, and ensuring that the `from` address is valid.
+    /// If `from_pool` is specified, it will use the address of the signer at index `idx`.
+    /// If `from` is specified, it will parse the address from the string.
+    /// If neither is specified, it will return an error.
     fn make_strict_call(
         &self,
         funcdef: &FunctionCallDefinition,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

If the chains addressed by `--rpc-url` and `--builder-url` have different chain_ids, you'll end up with an "invalid chain ID" error, which might make you think that there's a bug in contender. But what probably happened is that you provided an incorrect URL to one of the two.

## Solution

- [x] implement `Provider` for `BundleClient` so we can make a call to get its chain ID (and whatever else we want later on)
- [x] get chain IDs in `TestScenario::new` and return an error if they don't match

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes