### PR TITLE
chore(gitignore): ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ cargotest.toml
 *.db
 !test_fixtures/*.db
 report.csv
+
+.DS_Store


### PR DESCRIPTION
## Motivation

This isn't in the gitignore and some PRs contain an added .DS_Store

## Solution

add .DS_Store to gitignore

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes