### PR TITLE
support V4 (Prague) execution payloads

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "wasmtimer",
 ]
@@ -590,7 +590,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -881,7 +881,7 @@ checksum = "4f317d20f047b3de4d9728c556e2e9a92c9a507702d2016424cd8be13a74ca5e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "futures",
  "futures-utils-wasm",
@@ -890,7 +890,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -906,7 +906,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
 ]
@@ -1477,6 +1477,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1555,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1943,6 +1996,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.19",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2096,7 @@ dependencies = [
  "ansi_term",
  "async-trait",
  "clap",
+ "console-subscriber",
  "contender_core",
  "contender_engine_provider",
  "contender_report",
@@ -2041,7 +2134,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "tracing-subscriber 0.3.19",
 ]
@@ -2066,7 +2159,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "thiserror 2.0.12",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2734,7 +2827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
 dependencies = [
  "alloy-rlp",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "ed25519-dalek",
  "hex",
@@ -3347,7 +3440,10 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
+ "base64 0.21.7",
  "byteorder",
+ "flate2",
+ "nom",
  "num-traits",
 ]
 
@@ -3556,6 +3652,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,7 +3686,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3998,7 +4107,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2a320a3f1464e4094f780c4d48413acd786ce5627aaaecfac9e9c7431d13ae1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
@@ -4040,7 +4149,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -4051,7 +4160,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -4064,7 +4173,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "url",
 ]
 
@@ -4104,7 +4213,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -4129,7 +4238,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower",
+ "tower 0.5.2",
 ]
 
 [[package]]
@@ -4142,7 +4251,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower",
+ "tower 0.5.2",
  "url",
 ]
 
@@ -4152,7 +4261,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -4302,7 +4411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.22.1",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
@@ -4487,6 +4596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4529,7 +4644,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.10.0",
  "metrics",
  "metrics-util",
@@ -5240,7 +5355,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -5565,6 +5680,38 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5942,7 +6089,7 @@ version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -5971,7 +6118,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -6894,7 +7041,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -7283,7 +7430,7 @@ dependencies = [
  "reth-metrics",
  "reth-tasks",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -7544,7 +7691,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -7868,7 +8015,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "tracing-futures",
 ]
@@ -7934,7 +8081,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
 ]
@@ -8088,7 +8235,7 @@ dependencies = [
  "http",
  "jsonrpsee-http-client",
  "pin-project",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
 ]
@@ -9265,7 +9412,7 @@ version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -9475,7 +9622,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "http",
@@ -9775,6 +9922,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -9894,6 +10042,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9920,7 +10118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.9.1",
  "bytes",
  "futures-core",
@@ -9937,7 +10135,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ prometheus = "0.14"
 strum = "0.27.1"
 
 ## cli
+console-subscriber = "0.4.1"
 ansi_term = "0.12.1"
 clap = { version = "4.5.16" }
 csv = "1.3.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,8 +21,9 @@ contender_engine_provider = { workspace = true }
 contender_report = { workspace = true }
 
 ansi_term = { workspace = true }
+console-subscriber = { workspace = true }
 serde = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "tracing"] }
 tokio-util = { workspace = true }
 alloy = { workspace = true, features = [
     "full",

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -124,7 +124,7 @@ Requires --auth-rpc-url and --jwt-secret to be set.",
         long,
         short,
         value_enum,
-        default_value_t = EngineMessageVersion::V3
+        default_value_t = EngineMessageVersion::V4
     )]
     message_version: EngineMessageVersion,
 }

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -4,6 +4,7 @@ use super::EngineArgs;
 use crate::util::{BundleTypeCli, EngineParams, TxTypeCli};
 use alloy::primitives::utils::parse_units;
 use alloy::primitives::U256;
+use contender_engine_provider::reth_node_api::EngineApiMessageVersion;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, clap::Args)]
@@ -117,6 +118,24 @@ Requires --auth-rpc-url and --jwt-secret to be set.",
         visible_aliases = &["op"]
     )]
     pub use_op: bool,
+
+    /// Engine API Message Version
+    #[arg(
+        long,
+        short,
+        value_enum,
+        default_value_t = EngineMessageVersion::V3
+    )]
+    message_version: EngineMessageVersion,
+}
+
+#[derive(Copy, Debug, Clone, clap::ValueEnum)]
+enum EngineMessageVersion {
+    V1,
+    V2,
+    V3,
+    V4,
+    // V5,
 }
 
 impl AuthCliArgs {
@@ -130,6 +149,13 @@ impl AuthCliArgs {
                 auth_rpc_url: self.auth_rpc_url.to_owned().expect("auth_rpc_url"),
                 jwt_secret: self.jwt_secret.to_owned().expect("jwt_secret").into(),
                 use_op: self.use_op,
+                message_version: match self.message_version {
+                    EngineMessageVersion::V1 => EngineApiMessageVersion::V1,
+                    EngineMessageVersion::V2 => EngineApiMessageVersion::V2,
+                    EngineMessageVersion::V3 => EngineApiMessageVersion::V3,
+                    EngineMessageVersion::V4 => EngineApiMessageVersion::V4,
+                    // EngineMessageVersion::V5 => EngineApiMessageVersion::V5,
+                },
             };
             EngineParams::new(Arc::new(args.new_provider().await?), self.call_forkchoice)
         } else {

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -24,7 +24,9 @@ use contender_core::{
     test_scenario::{TestScenario, TestScenarioParams},
     BundleType,
 };
-use contender_engine_provider::{AdvanceChain, AuthProvider};
+use contender_engine_provider::{
+    reth_node_api::EngineApiMessageVersion, AdvanceChain, AuthProvider,
+};
 use contender_testfile::TestConfig;
 use op_alloy_network::Optimism;
 use std::{ops::Deref, path::PathBuf, sync::atomic::AtomicBool};
@@ -36,19 +38,28 @@ pub struct EngineArgs {
     pub auth_rpc_url: String,
     pub jwt_secret: PathBuf,
     pub use_op: bool,
+    pub message_version: EngineApiMessageVersion,
 }
 
 impl EngineArgs {
     pub async fn new_provider(&self) -> Result<AuthClient, Box<dyn std::error::Error>> {
         let provider: Box<dyn AdvanceChain + Send + Sync + 'static> = if self.use_op {
             Box::new(
-                AuthProvider::<Optimism>::from_jwt_file(&self.auth_rpc_url, &self.jwt_secret)
-                    .await?,
+                AuthProvider::<Optimism>::from_jwt_file(
+                    &self.auth_rpc_url,
+                    &self.jwt_secret,
+                    self.message_version,
+                )
+                .await?,
             )
         } else {
             Box::new(
-                AuthProvider::<AnyNetwork>::from_jwt_file(&self.auth_rpc_url, &self.jwt_secret)
-                    .await?,
+                AuthProvider::<AnyNetwork>::from_jwt_file(
+                    &self.auth_rpc_url,
+                    &self.jwt_secret,
+                    self.message_version,
+                )
+                .await?,
             )
         };
         Ok(AuthClient::new(provider))

--- a/crates/cli/src/commands/spamd.rs
+++ b/crates/cli/src/commands/spamd.rs
@@ -68,6 +68,7 @@ pub async fn spamd(
         let spam_res = commands::spam(&db, &args, &mut scenario).await;
         if let Err(e) = spam_res {
             error!("spam run failed: {e:?}");
+            scenario.ctx.cancel_token.cancel();
             break;
         } else {
             let run_id = spam_res.expect("spam");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,7 +16,6 @@ use commands::{
     ContenderCli, ContenderSubcommand, DbCommand, SetupCommandArgs, SpamCliArgs, SpamCommandArgs,
     SpamScenario,
 };
-use console_subscriber;
 use contender_core::{db::DbOps, error::ContenderError, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
 use default_scenarios::{fill_block::FillBlockCliArgs, BuiltinScenarioCli};

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,6 +16,7 @@ use commands::{
     ContenderCli, ContenderSubcommand, DbCommand, SetupCommandArgs, SpamCliArgs, SpamCommandArgs,
     SpamScenario,
 };
+use console_subscriber;
 use contender_core::{db::DbOps, error::ContenderError, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
 use default_scenarios::{fill_block::FillBlockCliArgs, BuiltinScenarioCli};
@@ -23,10 +24,10 @@ use rand::Rng;
 use std::{str::FromStr, sync::LazyLock};
 use tokio::sync::OnceCell;
 use tracing::{debug, info, warn};
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 use util::{data_dir, db_file, prompt_continue};
 
-use crate::util::init_reports_dir;
+use crate::util::{bold, init_reports_dir};
 
 static DB: LazyLock<SqliteDb> = std::sync::LazyLock::new(|| {
     let path = db_file().expect("failed to get DB file path");
@@ -37,7 +38,7 @@ static DB: LazyLock<SqliteDb> = std::sync::LazyLock::new(|| {
 static PROM: OnceCell<prometheus::Registry> = OnceCell::const_new();
 static LATENCY_HIST: OnceCell<prometheus::HistogramVec> = OnceCell::const_new();
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing();
     init_reports_dir();
@@ -258,10 +259,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")); // fallback if RUST_LOG is unset
 
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
+    let tokio_layer = console_subscriber::ConsoleLayer::builder()
+        .with_default_env()
+        .spawn();
+    let fmt_layer = fmt::layer()
         .with_target(true)
         .with_line_number(true)
+        .with_filter(filter);
+
+    tracing_subscriber::Registry::default()
+        .with(fmt_layer)
+        .with(tokio_layer)
         .init();
 }
 
@@ -277,12 +285,8 @@ fn check_spam_args(args: &SpamCliArgs) -> Result<bool, ContenderError> {
             "Missing params.",
             Some(format!(
                 "Either {} or {} must be set.",
-                ansi_term::Style::new()
-                    .bold()
-                    .paint("--txs-per-block (--tpb)"),
-                ansi_term::Style::new()
-                    .bold()
-                    .paint("--txs-per-second (--tps)"),
+                bold("--txs-per-block (--tpb)"),
+                bold("--txs-per-second (--tps)"),
             )),
         ));
     };
@@ -301,9 +305,9 @@ fn check_spam_args(args: &SpamCliArgs) -> Result<bool, ContenderError> {
 "Duration is set to {duration} {units}, which is quite high. Generating transactions and collecting results may take a long time.
 You may want to use {} with a lower spamming duration {} and a loop limit {}:\n
 \t{suggestion_cmd}\n",
-            ansi_term::Style::new().bold().paint("spam"),
-            ansi_term::Style::new().bold().paint("(-d)".to_string()),
-            ansi_term::Style::new().bold().paint("(-l)")
+            bold("spam"),
+            bold("(-d)"),
+            bold("(-l)")
     );
         return Ok(prompt_continue(None));
     }

--- a/crates/cli/src/util/provider.rs
+++ b/crates/cli/src/util/provider.rs
@@ -22,8 +22,8 @@ impl AdvanceChain for AuthClient {
         self.auth_provider
             .advance_chain(block_time)
             .await
-            .map_err(|e| {
-                match &e {
+            .inspect_err(|e| {
+                match e {
                     AuthProviderError::InternalError(_, err) => {
                         error!("AuthClient encountered an internal error. Please check contender_engine_provider debug logs for more details.");
                         if err.to_string().contains("Invalid newPayload") {
@@ -40,7 +40,6 @@ impl AdvanceChain for AuthClient {
                         error!("You may need to pass the {} flag to target this node.", bold("--op"));
                     }
                 }
-                e
             })
     }
 }

--- a/crates/cli/src/util/provider.rs
+++ b/crates/cli/src/util/provider.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use contender_engine_provider::{error::AuthProviderError, AdvanceChain, AuthResult};
 use tracing::error;
 
+use crate::util::bold;
+
 pub struct AuthClient {
     auth_provider: Box<dyn AdvanceChain + Send + Sync + 'static>,
 }
@@ -21,18 +23,21 @@ impl AdvanceChain for AuthClient {
             .advance_chain(block_time)
             .await
             .map_err(|e| {
-                match e {
-                    AuthProviderError::InternalError(_, _) => {
+                match &e {
+                    AuthProviderError::InternalError(_, err) => {
                         error!("AuthClient encountered an internal error. Please check contender_engine_provider debug logs for more details.");
+                        if err.to_string().contains("Invalid newPayload") {
+                            error!("You may need to specify a different engine message version with {}", bold("--message-version (-m)"));
+                        }
                     }
                     AuthProviderError::ConnectionFailed(_) => {
-                        error!("Please check the auth provider connection.");
+                        error!("Failed to connect to the auth API. You may need to enable the auth API on your target node.");
                     }
                     AuthProviderError::ExtraDataTooShort => {
-                        error!("You may need to remove the --op flag to target this node.");
+                        error!("You may need to remove the {} flag to target this node.", bold("--op"));
                     }
                     AuthProviderError::GasLimitRequired => {
-                        error!("You may need to pass the --op flag to target this node.");
+                        error!("You may need to pass the {} flag to target this node.", bold("--op"));
                     }
                 }
                 e

--- a/crates/cli/src/util/utils.rs
+++ b/crates/cli/src/util/utils.rs
@@ -7,7 +7,7 @@ use alloy::{
     rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
 };
-use ansi_term::Color;
+use ansi_term::{ANSIGenericString, Color};
 use contender_core::{
     error::ContenderError,
     generator::{
@@ -479,6 +479,12 @@ pub fn init_reports_dir() -> String {
 pub fn db_file() -> Result<String, Box<dyn std::error::Error>> {
     let data_path = data_dir()?;
     Ok(format!("{data_path}/contender.db"))
+}
+
+pub fn bold<'a>(msg: impl AsRef<str> + 'a) -> ANSIGenericString<'a, str> {
+    ansi_term::Style::new()
+        .bold()
+        .paint(msg.as_ref().to_owned())
 }
 
 #[cfg(test)]

--- a/crates/core/src/spammer/spammer_trait.rs
+++ b/crates/core/src/spammer/spammer_trait.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::AtomicBool;
+use std::time::Duration;
 use std::{pin::Pin, sync::Arc};
 
 use alloy::providers::Provider;
@@ -92,6 +93,8 @@ where
                                     is_fcu_done.store(true, std::sync::atomic::Ordering::SeqCst);
                                     ContenderError::with_err(e, "spammer failed to advance chain")
                                 })?;
+                        } else {
+                            tokio::time::sleep(Duration::from_secs(1)).await;
                         }
                     }
                 }

--- a/crates/engine_provider/src/engine.rs
+++ b/crates/engine_provider/src/engine.rs
@@ -4,7 +4,8 @@ use alloy::{
     consensus::{
         crypto::secp256k1::public_key_to_address, transaction::Recovered, SignableTransaction,
     },
-    primitives::{BlockHash, Bytes, B256, U256},
+    eips::eip7685::Requests,
+    primitives::{BlockHash, B256, U256},
     providers::Provider,
     signers::Signature,
     transports::TransportResult,
@@ -61,7 +62,7 @@ pub trait EngineApi<N: NetworkAttributes>: Send + Sync {
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
-        execution_requests: Vec<Bytes>,
+        execution_requests: Requests,
     ) -> TransportResult<PayloadStatus>;
 
     /// Updates the execution layer client with the given fork choice, as specified for the Paris
@@ -232,7 +233,7 @@ where
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
-        execution_requests: Vec<Bytes>,
+        execution_requests: Requests,
     ) -> TransportResult<PayloadStatus> {
         self.client()
             .request(

--- a/crates/engine_provider/src/lib.rs
+++ b/crates/engine_provider/src/lib.rs
@@ -9,3 +9,5 @@ mod valid_payload;
 pub use auth_provider::{AuthProvider, AuthResult, ProviderExt};
 pub use traits::AdvanceChain;
 pub use util::*;
+
+pub use reth_node_api;

--- a/crates/engine_provider/src/valid_payload.rs
+++ b/crates/engine_provider/src/valid_payload.rs
@@ -87,7 +87,9 @@ where
         while !status.is_valid() {
             if status.is_invalid() {
                 error!(?status, ?payload, "Invalid newPayloadV1",);
-                panic!("Invalid newPayloadV1: {status:?}");
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "Invalid newPayloadV1",
+                ));
             }
             status = self.new_payload_v1(payload.clone()).await?;
         }
@@ -102,7 +104,9 @@ where
         while !status.is_valid() {
             if status.is_invalid() {
                 error!(?status, ?payload, "Invalid newPayloadV2",);
-                panic!("Invalid newPayloadV2: {status:?}");
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "Invalid newPayloadV2",
+                ));
             }
             status = self.new_payload_v2(payload.clone()).await?;
         }
@@ -131,7 +135,9 @@ where
                     ?parent_beacon_block_root,
                     "Invalid newPayloadV3",
                 );
-                panic!("Invalid newPayloadV3: {status:?}");
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "Invalid newPayloadV3",
+                ));
             }
             if status.is_syncing() {
                 return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
@@ -175,7 +181,9 @@ where
                     ?execution_requests,
                     "Invalid newPayloadV4",
                 );
-                panic!("Invalid newPayloadV4: {status:?}");
+                return Err(alloy_json_rpc::RpcError::UnsupportedFeature(
+                    "Invalid newPayloadV4",
+                ));
             }
             if status.is_syncing() {
                 return Err(alloy_json_rpc::RpcError::UnsupportedFeature(


### PR DESCRIPTION
## Motivation

fixes https://github.com/flashbots/contender/issues/277

## Solution

It's not straightforward or necessarily reliable to determine a target chain's hard-fork status at runtime, so instead of trying to detect it automatically, I just added new CLI flag `-m` to specify which message version to use (`v1` through `v4`).

Tested v4 execution payloads successfully using reth as described [in the issue](https://github.com/flashbots/contender/issues/277).

## TODO

- [ ] friendly error message when the user chooses the wrong message version (which will be evidenced by an invalid payload)

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes