### PR TITLE
add erc20 builtin scenario

### DIFF
--- a/crates/cli/src/default_scenarios/contracts/mod.rs
+++ b/crates/cli/src/default_scenarios/contracts/mod.rs
@@ -13,7 +13,7 @@ pub const TEST_TOKEN: CompiledContract<&'static str> = CompiledContract {
     name: "testToken",
 };
 
-/// Helper function to create a `CompiledContract` for the `SpamMe` contract with constructor arguments.
+/// Create a `CompiledContract` for the `TestToken` contract with constructor arguments.
 pub fn test_token(token_num: u32, initial_supply: U256) -> CompiledContract<String> {
     let mut bytecode = TEST_TOKEN.bytecode.to_string();
     // Append the initial supply as a 32-byte hex-encoded value

--- a/crates/cli/src/default_scenarios/erc20.rs
+++ b/crates/cli/src/default_scenarios/erc20.rs
@@ -1,0 +1,96 @@
+use alloy::primitives::{Address, U256};
+use contender_core::generator::{types::SpamRequest, CreateDefinition, FunctionCallDefinition};
+use contender_testfile::TestConfig;
+
+use crate::{
+    commands::common::parse_amount,
+    default_scenarios::{builtin::ToTestConfig, contracts::test_token},
+};
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct Erc20CliArgs {
+    #[arg(
+        short,
+        long,
+        long_help = "The amount to send in each spam tx.",
+        default_value = "0.00001 ether",
+        value_parser = parse_amount,
+    )]
+    pub send_amount: U256,
+
+    #[arg(
+        short,
+        long,
+        long_help = "The amount of tokens to give each spammer account before spamming starts.",
+        default_value = "1000000 ether",
+        value_parser = parse_amount,
+    )]
+    pub fund_amount: U256,
+
+    #[arg(
+        short = 'r',
+        long = "recipient",
+        long_help = "The address to receive tokens sent by spam txs. By default, the sender receives their own tokens."
+    )]
+    pub token_recipient: Option<Address>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Erc20Args {
+    pub send_amount: U256,
+    pub fund_amount: U256,
+    /// populated by AgentStore for setup step
+    pub fund_recipients: Vec<Address>,
+    /// given by user to override token recipient
+    pub token_recipient: Option<String>,
+}
+
+impl Erc20Args {
+    pub fn from_cli_args(args: Erc20CliArgs, fund_recipients: &[Address]) -> Self {
+        Erc20Args {
+            fund_amount: args.fund_amount,
+            fund_recipients: fund_recipients.to_vec(),
+            send_amount: args.send_amount,
+            token_recipient: args.token_recipient.map(|addr| addr.to_string()),
+        }
+    }
+}
+
+impl ToTestConfig for Erc20Args {
+    fn to_testconfig(&self) -> contender_testfile::TestConfig {
+        let token = test_token(0, U256::MAX);
+        // transfer eth from admin (total supply is minted to that account) to spammers
+        let setup_steps = self
+            .fund_recipients
+            .iter()
+            .map(|recipient| {
+                FunctionCallDefinition::new(token.template_name())
+                    .with_from_pool("admin")
+                    .with_signature("transfer(address guy, uint256 wad)")
+                    .with_args(&[recipient.to_string(), self.fund_amount.to_string()])
+            })
+            .collect();
+
+        TestConfig {
+            env: None,
+            create: Some(vec![CreateDefinition {
+                contract: token.to_owned(),
+                from: None,
+                from_pool: Some("admin".to_owned()),
+            }]),
+            setup: Some(setup_steps),
+            // transfer tokens to self
+            spam: Some(vec![SpamRequest::new_tx(
+                FunctionCallDefinition::new(token.template_name())
+                    .with_from_pool("spammers")
+                    .with_signature("transfer(address guy, uint256 wad)")
+                    .with_args(&[
+                        self.token_recipient
+                            .to_owned()
+                            .unwrap_or("{_sender}".to_owned()),
+                        self.send_amount.to_string(),
+                    ]),
+            )]),
+        }
+    }
+}

--- a/crates/cli/src/default_scenarios/mod.rs
+++ b/crates/cli/src/default_scenarios/mod.rs
@@ -1,6 +1,7 @@
 pub mod blobs;
 mod builtin;
 mod contracts;
+pub mod erc20;
 pub mod eth_functions;
 pub mod fill_block;
 pub mod storage;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,7 +3,6 @@ mod default_scenarios;
 mod util;
 
 use alloy::{
-    hex,
     network::AnyNetwork,
     providers::{DynProvider, ProviderBuilder},
     rpc::client::ClientBuilder,
@@ -19,14 +18,13 @@ use commands::{
 use contender_core::{db::DbOps, error::ContenderError, generator::RandSeed};
 use contender_sqlite::{SqliteDb, DB_VERSION};
 use default_scenarios::{fill_block::FillBlockCliArgs, BuiltinScenarioCli};
-use rand::Rng;
 use std::{str::FromStr, sync::LazyLock};
 use tokio::sync::OnceCell;
 use tracing::{debug, info, warn};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 use util::{data_dir, db_file, prompt_continue};
 
-use crate::util::{bold, init_reports_dir};
+use crate::util::{bold, init_reports_dir, load_seedfile};
 
 static DB: LazyLock<SqliteDb> = std::sync::LazyLock::new(|| {
     let path = db_file().expect("failed to get DB file path");
@@ -75,22 +73,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DB.create_tables()?;
     }
     let db = DB.clone();
-    let data_path = data_dir()?;
     let db_path = db_file()?;
 
-    let seed_path = format!("{}/seed", &data_path);
-    if !std::path::Path::new(&seed_path).exists() {
-        info!("generating seed file at {}", &seed_path);
-        let mut rng = rand::thread_rng();
-        let seed: [u8; 32] = rng.gen();
-        let seed_hex = hex::encode(seed);
-        std::fs::write(&seed_path, seed_hex).expect("failed to write seed file");
-    }
-
-    let stored_seed = format!(
-        "0x{}",
-        std::fs::read_to_string(&seed_path).expect("failed to read seed file")
-    );
+    let stored_seed = load_seedfile()?;
 
     match args.command {
         ContenderSubcommand::Db { command } => match command {
@@ -195,14 +180,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let scenario = if let Some(testfile) = testfile {
                 SpamScenario::Testfile(testfile)
             } else if let Some(config) = builtin_scenario_config {
-                SpamScenario::Builtin(config.to_builtin_scenario(&provider, &spam_args).await?)
+                SpamScenario::Builtin(config.to_builtin_scenario(&provider, &args).await?)
             } else {
                 // default to fill-block scenario
                 SpamScenario::Builtin(
                     BuiltinScenarioCli::FillBlock(FillBlockCliArgs {
                         max_gas_per_block: None,
                     })
-                    .to_builtin_scenario(&provider, &spam_args)
+                    .to_builtin_scenario(&provider, &args)
                     .await?,
                 )
             };

--- a/crates/core/src/generator/types.rs
+++ b/crates/core/src/generator/types.rs
@@ -27,6 +27,10 @@ impl SpamRequest {
     pub fn is_bundle(&self) -> bool {
         matches!(self, SpamRequest::Bundle(_))
     }
+
+    pub fn new_tx(fn_call: FunctionCallDefinition) -> Self {
+        Self::Tx(Box::new(fn_call))
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Send ERC20 transactions. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- TestToken mints the whole supply to the creator, so we dynamically create the setup steps based on the number of spammer accounts, to transfer tokens to each spammer account before spamming
- new `erc20` subcommand in `contender spam`
  - transfers tokens to self by default
  - cli flags to control num tokens sent to each spammer, how much they send in each tx, and the account to which they send the tokens

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes