### PR TITLE
ignore blob fee error; if call fails, return 0

### DIFF
--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -1,5 +1,5 @@
 use crate::{error::ContenderError, generator::types::AnyProvider, Result};
-use alloy::{network::EthereumWallet, providers::Provider};
+use alloy::providers::Provider;
 use tracing::{debug, warn};
 
 /// Derive the block time from the first two blocks after genesis.

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -1,6 +1,6 @@
 use crate::{error::ContenderError, generator::types::AnyProvider, Result};
-use alloy::providers::Provider;
-use tracing::debug;
+use alloy::{network::EthereumWallet, providers::Provider};
+use tracing::{debug, warn};
 
 /// Derive the block time from the first two blocks after genesis.
 pub async fn get_block_time(rpc_client: &AnyProvider) -> Result<u64> {
@@ -31,6 +31,15 @@ pub async fn get_block_time(rpc_client: &AnyProvider) -> Result<u64> {
         1
     };
     Ok(block_time_secs)
+}
+
+/// returns blob fee, or 0 if the RPC call fails.
+pub async fn get_blob_fee_maybe(rpc_client: &AnyProvider) -> u128 {
+    let res = rpc_client.get_blob_base_fee().await;
+    if res.is_err() {
+        warn!("failed to get blob base fee; defaulting to 0");
+    }
+    res.unwrap_or(0)
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

on chains that don't support blobs, calling `eth_getBlobBaseFee` produces an error, which in most cases, crashes contender.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

use a new helper function `get_blob_fee_maybe` which behaves as follows: if the call to `eth_getBlobBaseFee` fails, log a warning and return 0.

Some chains don't support blobs and that's OK <3

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes