### PR TITLE
add blob params to blob tx reqs when estimating gas

### DIFF
--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -702,6 +702,11 @@ where
         let key = keccak256(tx_req.input.input.to_owned().unwrap_or_default());
 
         if let std::collections::hash_map::Entry::Vacant(_) = self.gas_limits.entry(key) {
+            let mut tx_req = tx_req.to_owned();
+            if let Some(sidecar) = &tx_req.sidecar {
+                tx_req.max_fee_per_blob_gas = Some(blob_gas_price);
+                tx_req.blob_versioned_hashes = Some(sidecar.versioned_hashes().collect());
+            }
             let gas_limit = if let Some(gas) = tx_req.gas {
                 gas
             } else {


### PR DESCRIPTION
## Motivation

```
Error: failed to prepare tx failed to estimate gas for tx 
ErrorResp(ErrorPayload { code: -32003, message: "max fee per blob gas less than block blob gas fee", data: None }
```

## Solution

add `max_fee_per_blob_gas` and `blob_versioned_hashes` to the tx request before estimating gas.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes