### PR TITLE
bugfix: docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash && \
     cp /root/.foundry/bin/anvil /app/contender-dist/bin/
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # Install runtime dependencies
 RUN apt-get update && \


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

error when running dockerized contender:

```
contender: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by contender)
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

upgrade runtime image to debian Trixie

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes