### PR TITLE
Feat/simpler constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,6 +2131,7 @@ dependencies = [
  "async-trait",
  "contender_bundle_provider",
  "contender_engine_provider",
+ "contender_testfile",
  "eyre",
  "futures",
  "prometheus",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -245,7 +245,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")); // fallback if RUST_LOG is unset
+    let filter = EnvFilter::try_from_default_env().ok(); // fallback if RUST_LOG is unset
     #[cfg(feature = "async-tracing")]
     {
         use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Layer};
@@ -265,11 +265,7 @@ fn init_tracing() {
 
     #[cfg(not(feature = "async-tracing"))]
     {
-        tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_target(true)
-            .with_line_number(true)
-            .init();
+        contender_core::util::init_core_tracing(filter);
     }
 }
 

--- a/crates/cli/src/util/utils.rs
+++ b/crates/cli/src/util/utils.rs
@@ -347,8 +347,12 @@ pub fn spam_callback_default(
 ) -> TypedSpamCallback {
     if let Some(rpc_client) = rpc_client {
         if log_txs {
-            let log_callback =
-                LogCallback::new(rpc_client.clone(), auth_client, send_fcu, cancel_token);
+            let log_callback = LogCallback {
+                rpc_provider: rpc_client.clone(),
+                auth_provider: auth_client,
+                send_fcu,
+                cancel_token,
+            };
             return TypedSpamCallback::Log(log_callback);
         }
     }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,3 +29,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
 contender_testfile = { workspace = true }
+
+[package.metadata.cargo-udeps.ignore]
+development = ["contender_testfile"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,3 +26,6 @@ tokio-util = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+contender_testfile = { workspace = true }

--- a/crates/core/src/generator/agent_pools.rs
+++ b/crates/core/src/generator/agent_pools.rs
@@ -1,0 +1,50 @@
+use crate::{
+    agent_controller::AgentStore,
+    generator::{seeder::rand_seed::SeedGenerator, PlanConfig},
+};
+
+pub trait AgentPools {
+    fn build_agent_store(&self, seed: &impl SeedGenerator, agent_spec: AgentSpec) -> AgentStore;
+}
+
+/// Defines the number of accounts to generate for each category of agent: creators, setter-uppers, and spammers.
+/// "Agents" in contender are referred to by name (defined by `from_pool` in scenario specs) and may hold many accounts.
+#[derive(Debug)]
+pub struct AgentSpec {
+    /// number of accounts to generate per `create` agent
+    create_accounts: usize,
+
+    /// number of accounts to generate per `setup` agent
+    setup_accounts: usize,
+
+    /// number of accounts to generate per `spam` agent
+    spam_accounts: usize,
+}
+
+impl Default for AgentSpec {
+    fn default() -> Self {
+        AgentSpec {
+            create_accounts: 1,
+            setup_accounts: 1,
+            spam_accounts: 10,
+        }
+    }
+}
+
+impl<P> AgentPools for P
+where
+    P: PlanConfig<String>,
+{
+    fn build_agent_store(&self, seed: &impl SeedGenerator, agent_spec: AgentSpec) -> AgentStore {
+        let create_pools = self.get_create_pools();
+        let setup_pools = self.get_setup_pools();
+        let spam_pools = self.get_spam_pools();
+
+        let mut agents = AgentStore::new();
+        agents.init(&create_pools, agent_spec.create_accounts, seed);
+        agents.init(&setup_pools, agent_spec.setup_accounts, seed);
+        agents.init(&spam_pools, agent_spec.spam_accounts, seed);
+
+        agents
+    }
+}

--- a/crates/core/src/generator/agent_pools.rs
+++ b/crates/core/src/generator/agent_pools.rs
@@ -31,6 +31,23 @@ impl Default for AgentSpec {
     }
 }
 
+impl AgentSpec {
+    pub fn create_accounts(mut self, count: usize) -> Self {
+        self.create_accounts = count;
+        self
+    }
+
+    pub fn setup_accounts(mut self, count: usize) -> Self {
+        self.setup_accounts = count;
+        self
+    }
+
+    pub fn spam_accounts(mut self, count: usize) -> Self {
+        self.spam_accounts = count;
+        self
+    }
+}
+
 impl<P> AgentPools for P
 where
     P: PlanConfig<String>,

--- a/crates/core/src/generator/mod.rs
+++ b/crates/core/src/generator/mod.rs
@@ -1,7 +1,7 @@
-mod r#trait;
-
+pub mod agent_pools;
 mod create_def;
 mod function_def;
+mod r#trait;
 
 pub mod constants;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,7 +3,7 @@ pub mod buckets;
 pub mod db;
 pub mod error;
 pub mod generator;
-mod orchestrator;
+pub mod orchestrator;
 pub mod provider;
 pub mod spammer;
 pub mod test_scenario;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,3 +15,4 @@ pub use alloy;
 pub use contender_bundle_provider::bundle::BundleType;
 pub use orchestrator::{Contender, ContenderCtx, RunOpts};
 pub use tokio::task as tokio_task;
+pub use tokio_util::sync::CancellationToken;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod buckets;
 pub mod db;
 pub mod error;
 pub mod generator;
+mod orchestrator;
 pub mod provider;
 pub mod spammer;
 pub mod test_scenario;
@@ -12,4 +13,5 @@ pub type Result<T> = std::result::Result<T, error::ContenderError>;
 
 pub use alloy;
 pub use contender_bundle_provider::bundle::BundleType;
+pub use orchestrator::{Contender, ContenderCtx, RunOpts};
 pub use tokio::task as tokio_task;

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -288,6 +288,10 @@ where
     }
 
     pub fn build(self) -> ContenderCtx<D, S, P> {
+        // always try to create tables before building, so user doesn't have to think about it later.
+        // we'll get an error if the tables already exist, but it's safe to ignore
+        self.db.create_tables().unwrap_or_default();
+
         ContenderCtx {
             config: self.config,
             db: self.db,

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -286,6 +286,10 @@ where
         self.funding = f;
         self
     }
+    pub fn seeder(mut self, s: S) -> Self {
+        self.seeder = s;
+        self
+    }
 
     pub fn build(self) -> ContenderCtx<D, S, P> {
         // always try to create tables before building, so user doesn't have to think about it later.

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -495,7 +495,7 @@ where
 
         // add run to DB
         let run_req = opts.create_spam_run_request(
-            scenario.rpc_url.to_string(),
+            &scenario.rpc_url,
             Duration::from_secs(self.ctx.pending_tx_timeout_secs),
             SP::duration_units(opts.periods),
         );

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -1,0 +1,260 @@
+//! High-level builder/orchestrator to create a TestScenario and run a Spammer with sane defaults.
+use std::{collections::HashMap, sync::Arc};
+
+use crate::{
+    agent_controller::AgentStore,
+    db::DbOps,
+    generator::{
+        agent_pools::AgentPools,
+        seeder::{rand_seed::SeedGenerator, Seeder},
+        templater::Templater,
+        PlanConfig,
+    },
+    spammer::{tx_actor::TxActorHandle, OnBatchSent, OnTxSent, Spammer},
+    test_scenario::{PrometheusCollector, TestScenario, TestScenarioParams},
+    Result,
+};
+use alloy::{consensus::TxType, signers::local::PrivateKeySigner, transports::http::reqwest::Url};
+use contender_bundle_provider::bundle::BundleType;
+use contender_engine_provider::AdvanceChain;
+
+/// Unified context that captures everything needed to spin up a `TestScenario`.
+pub struct ContenderCtx<D, S, P>
+where
+    D: DbOps + Send + Sync + 'static,
+    S: Seeder + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    pub config: P,
+    pub db: Arc<D>,
+    pub seeder: S,
+
+    // Minimal required inputs:
+    pub rpc_url: Url,
+
+    // Optional extras (all defaulted):
+    pub builder_rpc_url: Option<Url>,
+    pub agent_store: AgentStore,
+    pub user_signers: Vec<PrivateKeySigner>,
+    pub tx_type: TxType,
+    pub bundle_type: BundleType,
+    pub pending_tx_timeout_secs: u64,
+    pub extra_msg_handles: Option<HashMap<String, Arc<TxActorHandle>>>,
+    pub auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    pub prometheus: PrometheusCollector,
+}
+
+impl<D, S, P> ContenderCtx<D, S, P>
+where
+    D: DbOps + Send + Sync + 'static,
+    S: SeedGenerator + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    pub fn builder(config: P, db: D, seeder: S, rpc_url: Url) -> ContenderCtxBuilder<D, S, P> {
+        let agents = config.build_agent_store(&seeder, Default::default());
+        ContenderCtxBuilder {
+            config,
+            db: db.into(),
+            agent_store: agents,
+            seeder,
+            rpc_url,
+            builder_rpc_url: None,
+            user_signers: vec![],
+            tx_type: TxType::Eip1559,
+            bundle_type: BundleType::default(),
+            pending_tx_timeout_secs: 12,
+            extra_msg_handles: None,
+            auth_provider: None,
+            prometheus: PrometheusCollector::default(),
+        }
+    }
+
+    /// Materialize a fresh TestScenario using the context and defaults/overrides.
+    pub async fn build_scenario(&self) -> Result<TestScenario<D, S, P>> {
+        let params = TestScenarioParams {
+            rpc_url: self.rpc_url.clone(),
+            builder_rpc_url: self.builder_rpc_url.clone(),
+            signers: self.user_signers.clone(),
+            agent_store: self.agent_store.clone(),
+            tx_type: self.tx_type,
+            pending_tx_timeout_secs: self.pending_tx_timeout_secs,
+            bundle_type: self.bundle_type,
+            extra_msg_handles: self.extra_msg_handles.clone(),
+        };
+
+        TestScenario::new(
+            self.config.clone(),
+            self.db.clone(),
+            self.seeder.clone(),
+            params,
+            self.auth_provider.clone(),
+            self.prometheus.clone(),
+        )
+        .await
+    }
+}
+
+/// Builder with sane defaults; only (config, db, seeder, rpc_url) are required.
+pub struct ContenderCtxBuilder<D, S, P>
+where
+    D: DbOps + Send + Sync + 'static,
+    S: Seeder + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    config: P,
+    db: Arc<D>,
+    seeder: S,
+    rpc_url: Url,
+
+    builder_rpc_url: Option<Url>,
+    agent_store: AgentStore,
+    user_signers: Vec<PrivateKeySigner>,
+    tx_type: TxType,
+    bundle_type: BundleType,
+    pending_tx_timeout_secs: u64,
+    extra_msg_handles: Option<HashMap<String, Arc<TxActorHandle>>>,
+    auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    prometheus: PrometheusCollector,
+}
+
+impl<D, S, P> ContenderCtxBuilder<D, S, P>
+where
+    D: DbOps + Send + Sync + 'static,
+    S: Seeder + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    pub fn builder_rpc_url(mut self, url: Url) -> Self {
+        self.builder_rpc_url = Some(url);
+        self
+    }
+    pub fn agent_store(mut self, store: AgentStore) -> Self {
+        self.agent_store = store;
+        self
+    }
+    pub fn user_signers(mut self, signers: Vec<PrivateKeySigner>) -> Self {
+        self.user_signers = signers;
+        self
+    }
+    pub fn tx_type(mut self, t: TxType) -> Self {
+        self.tx_type = t;
+        self
+    }
+    pub fn bundle_type(mut self, b: BundleType) -> Self {
+        self.bundle_type = b;
+        self
+    }
+    pub fn pending_tx_timeout_secs(mut self, s: u64) -> Self {
+        self.pending_tx_timeout_secs = s;
+        self
+    }
+    pub fn extra_msg_handles(mut self, m: HashMap<String, Arc<TxActorHandle>>) -> Self {
+        self.extra_msg_handles = Some(m);
+        self
+    }
+    pub fn auth_provider(mut self, a: Arc<dyn AdvanceChain + Send + Sync + 'static>) -> Self {
+        self.auth_provider = Some(a);
+        self
+    }
+    pub fn prometheus(mut self, p: PrometheusCollector) -> Self {
+        self.prometheus = p;
+        self
+    }
+
+    pub fn build(self) -> ContenderCtx<D, S, P> {
+        ContenderCtx {
+            config: self.config,
+            db: self.db,
+            seeder: self.seeder,
+            rpc_url: self.rpc_url,
+            builder_rpc_url: self.builder_rpc_url,
+            agent_store: self.agent_store,
+            user_signers: self.user_signers,
+            tx_type: self.tx_type,
+            bundle_type: self.bundle_type,
+            pending_tx_timeout_secs: self.pending_tx_timeout_secs,
+            extra_msg_handles: self.extra_msg_handles,
+            auth_provider: self.auth_provider,
+            prometheus: self.prometheus,
+        }
+    }
+}
+
+/// Minimal knobs for running a spammer. Defaults are conservative.
+#[derive(Clone, Copy)]
+pub struct RunOpts {
+    pub txs_per_period: u64,
+    pub periods: u64,
+    pub run_id: Option<u64>,
+}
+
+impl Default for RunOpts {
+    fn default() -> Self {
+        Self {
+            txs_per_period: 10,
+            periods: 1,
+            run_id: None,
+        }
+    }
+}
+
+impl RunOpts {
+    pub fn txs_per_period(mut self, n: u64) -> Self {
+        self.txs_per_period = n;
+        self
+    }
+    pub fn periods(mut self, n: u64) -> Self {
+        self.periods = n;
+        self
+    }
+    pub fn run_id(mut self, id: u64) -> Self {
+        self.run_id = Some(id);
+        self
+    }
+}
+
+/// Orchestrator that plugs a built scenario into any `Spammer`.
+pub struct Contender<D, S, P>
+where
+    D: DbOps + Send + Sync + 'static,
+    S: SeedGenerator + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    ctx: ContenderCtx<D, S, P>,
+}
+
+impl<D, S, P> Contender<D, S, P>
+where
+    D: DbOps + Send + Sync + 'static,
+    S: SeedGenerator + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    pub fn new(ctx: ContenderCtx<D, S, P>) -> Self {
+        Self { ctx }
+    }
+
+    /// Run contract deployments and setup transactions.
+    pub async fn init_scenario(&self) -> Result<()> {
+        let mut scenario = self.ctx.build_scenario().await?;
+        scenario.deploy_contracts().await?;
+        scenario.run_setup().await?;
+        Ok(())
+    }
+
+    /// Run the spammer.
+    pub async fn spam<F, SP>(&self, spammer: SP, callback: Arc<F>, opts: RunOpts) -> Result<()>
+    where
+        F: OnTxSent + OnBatchSent + Send + Sync + 'static,
+        SP: Spammer<F, D, S, P>,
+    {
+        let mut scenario = self.ctx.build_scenario().await?;
+        spammer
+            .spam_rpc(
+                &mut scenario,
+                opts.txs_per_period,
+                opts.periods,
+                opts.run_id,
+                callback,
+            )
+            .await
+    }
+}

--- a/crates/core/src/spammer/blockwise.rs
+++ b/crates/core/src/spammer/blockwise.rs
@@ -54,6 +54,10 @@ where
             .boxed())
     }
 
+    fn duration_units(periods: u64) -> crate::db::SpamDuration {
+        crate::db::SpamDuration::Blocks(periods)
+    }
+
     fn context(&self) -> &SpamRunContext {
         &self.context
     }

--- a/crates/core/src/spammer/spammer_trait.rs
+++ b/crates/core/src/spammer/spammer_trait.rs
@@ -8,6 +8,7 @@ use futures::Stream;
 use futures::StreamExt;
 use tracing::{info, warn};
 
+use crate::db::SpamDuration;
 use crate::{
     db::DbOps,
     error::ContenderError,
@@ -60,6 +61,8 @@ where
         &self,
         scenario: &mut TestScenario<D, S, P>,
     ) -> impl std::future::Future<Output = Result<Pin<Box<dyn Stream<Item = SpamTrigger> + Send>>>>;
+
+    fn duration_units(periods: u64) -> SpamDuration;
 
     fn spam_rpc(
         &self,

--- a/crates/core/src/spammer/timed.rs
+++ b/crates/core/src/spammer/timed.rs
@@ -54,6 +54,10 @@ where
         }
     }
 
+    fn duration_units(periods: u64) -> crate::db::SpamDuration {
+        crate::db::SpamDuration::Seconds(periods)
+    }
+
     fn context(&self) -> &SpamRunContext {
         &self.context
     }

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -7,6 +7,7 @@ use alloy::providers::PendingTransactionConfig;
 use contender_engine_provider::{AdvanceChain, DEFAULT_BLOCK_TIME};
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 pub trait OnTxSent<K = String, V = String>
@@ -100,18 +101,28 @@ pub struct LogCallback {
 }
 
 impl LogCallback {
-    pub fn new(
-        rpc_provider: Arc<AnyProvider>,
-        auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
-        send_fcu: bool,
-        cancel_token: tokio_util::sync::CancellationToken,
-    ) -> Self {
+    pub fn new(rpc_provider: Arc<AnyProvider>) -> Self {
         Self {
             rpc_provider,
-            auth_provider,
-            send_fcu,
-            cancel_token,
+            auth_provider: None,
+            send_fcu: false,
+            cancel_token: CancellationToken::default(),
         }
+    }
+    pub fn auth_provider(
+        mut self,
+        provider: Arc<dyn AdvanceChain + Send + Sync + 'static>,
+    ) -> Self {
+        self.auth_provider = Some(provider);
+        self
+    }
+    pub fn send_fcu(mut self, send_fcu: bool) -> Self {
+        self.send_fcu = send_fcu;
+        self
+    }
+    pub fn cancel_token(mut self, token: CancellationToken) -> Self {
+        self.cancel_token = token;
+        self
     }
 }
 

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -2,6 +2,7 @@ use crate::{error::ContenderError, generator::types::AnyProvider, Result};
 use alloy::{providers::Provider, signers::local::PrivateKeySigner};
 use std::str::FromStr;
 use tracing::{debug, warn};
+use tracing_subscriber::EnvFilter;
 
 /// Derive the block time from the first two blocks after genesis.
 pub async fn get_block_time(rpc_client: &AnyProvider) -> Result<u64> {
@@ -78,4 +79,13 @@ pub fn default_signers() -> Vec<PrivateKeySigner> {
         .into_iter()
         .map(|k| PrivateKeySigner::from_str(k).expect("Invalid private key"))
         .collect::<Vec<PrivateKeySigner>>()
+}
+
+pub fn init_core_tracing(filter: Option<EnvFilter>) {
+    let filter = filter.unwrap_or(EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_line_number(true)
+        .init();
 }

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -1,5 +1,6 @@
 use crate::{error::ContenderError, generator::types::AnyProvider, Result};
-use alloy::providers::Provider;
+use alloy::{providers::Provider, signers::local::PrivateKeySigner};
+use std::str::FromStr;
 use tracing::{debug, warn};
 
 /// Derive the block time from the first two blocks after genesis.
@@ -57,4 +58,24 @@ impl From<(u128, u128, u64)> for ExtraTxParams {
             chain_id,
         }
     }
+}
+
+pub const DEFAULT_PRV_KEYS: [&str; 10] = [
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+    "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+    "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+    "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+    "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
+    "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
+    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
+    "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
+    "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
+];
+
+pub fn default_signers() -> Vec<PrivateKeySigner> {
+    DEFAULT_PRV_KEYS
+        .into_iter()
+        .map(|k| PrivateKeySigner::from_str(k).expect("Invalid private key"))
+        .collect::<Vec<PrivateKeySigner>>()
 }

--- a/crates/report/src/command.rs
+++ b/crates/report/src/command.rs
@@ -19,6 +19,8 @@ use csv::WriterBuilder;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::env;
+use std::fs;
+use std::path::Path;
 use std::str::FromStr;
 use tracing::{debug, info};
 
@@ -29,6 +31,11 @@ pub async fn report(
     data_dir: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let num_runs = db.num_runs()?;
+
+    let data_path = Path::new(data_dir).join("reports");
+    if !data_path.exists() {
+        fs::create_dir_all(data_path)?;
+    }
 
     if num_runs == 0 {
         info!("No runs found in the database. Exiting.");

--- a/crates/sqlite_db/src/lib.rs
+++ b/crates/sqlite_db/src/lib.rs
@@ -345,7 +345,7 @@ impl DbOps for SqliteDb {
                 .reduce(|ac, c| format!("{ac}\n{c}"))
                 .unwrap_or_default(),
         ))
-        .map_err(|e| ContenderError::with_err(e, "failed to execute batch"))?;
+        .map_err(|e| ContenderError::with_err(e, "[insert_named_txs] failed to execute batch"))?;
         Ok(())
     }
 
@@ -447,7 +447,7 @@ impl DbOps for SqliteDb {
                 .reduce(|ac, c| format!("{ac}\n{c}"))
                 .unwrap_or_default(),
         ))
-        .map_err(|e| ContenderError::with_err(e, "failed to execute batch"))?;
+        .map_err(|e| ContenderError::with_err(e, "[insert_run_txs] failed to execute batch"))?;
         Ok(())
     }
 
@@ -474,7 +474,9 @@ impl DbOps for SqliteDb {
                     .reduce(|acc, curr| format!("{acc}\n{curr}"))
                     .unwrap_or_default(),
             ))
-            .map_err(|e| ContenderError::with_err(e, "failed to execute batch"))?;
+            .map_err(|e| {
+                ContenderError::with_err(e, "[insert_latency_metrics] failed to execute batch")
+            })?;
         }
         Ok(())
     }

--- a/crates/sqlite_db/src/lib.rs
+++ b/crates/sqlite_db/src/lib.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use alloy::{
     hex::{FromHex, ToHexExt},
     primitives::{Address, TxHash},
@@ -13,6 +11,7 @@ use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{params, types::FromSql, Row};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Increment this whenever making changes to the DB schema.
 pub static DB_VERSION: u64 = 3;

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -428,13 +428,11 @@ mod more_tests {
         let ctx = ContenderCtx::builder(config, db, seeder, anvil.endpoint_url()).build();
         let contender = Contender::new(ctx);
 
-        // run contract deployments & setup txs (optional if your scenario doesn't have any of those steps)
-        contender.init_scenario().await?;
+        contender.initialize().await?;
 
-        // run spammer
         let spammer = TimedSpammer::new(Duration::from_secs(1));
         let callback = NilCallback;
-        let opts = RunOpts::default().txs_per_period(100).periods(3);
+        let opts = RunOpts::new().txs_per_period(100).periods(3);
         contender.spam(spammer, callback.into(), opts).await?;
 
         Ok(())

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -400,3 +400,43 @@ pub mod tests {
         assert_eq!(placeholder_map.len(), 3);
     }
 }
+
+#[cfg(test)]
+mod more_tests {
+    use super::*;
+    use alloy::node_bindings::Anvil;
+    use contender_core::{
+        db::MockDb,
+        generator::{types::SpamRequest, FunctionCallDefinition, RandSeed},
+        spammer::{NilCallback, TimedSpammer},
+        Contender, ContenderCtx, RunOpts,
+    };
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn contender_ctx_builder_runs() -> Result<(), Box<dyn std::error::Error>> {
+        let anvil = Anvil::new().spawn();
+
+        let config = TestConfig::new().with_spam(vec![SpamRequest::new_tx(
+            &FunctionCallDefinition::new("{_sender}") // send tx to self
+                .with_from_pool("spammers")
+                .with_kind("cargo_test"),
+        )]);
+
+        let db = MockDb;
+        let seeder = RandSeed::new();
+        let ctx = ContenderCtx::builder(config, db, seeder, anvil.endpoint_url()).build();
+        let contender = Contender::new(ctx);
+
+        // run contract deployments & setup txs (optional if your scenario doesn't have any of those steps)
+        contender.init_scenario().await?;
+
+        // run spammer
+        let spammer = TimedSpammer::new(Duration::from_secs(1));
+        let callback = NilCallback;
+        let opts = RunOpts::default().txs_per_period(100).periods(3);
+        contender.spam(spammer, callback.into(), opts).await?;
+
+        Ok(())
+    }
+}

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -426,9 +426,7 @@ mod more_tests {
         let db = MockDb;
         let seeder = RandSeed::new();
         let ctx = ContenderCtx::builder(config, db, seeder, anvil.endpoint_url()).build();
-        let contender = Contender::new(ctx);
-
-        contender.initialize().await?;
+        let mut contender = Contender::new(ctx);
 
         let spammer = TimedSpammer::new(Duration::from_secs(1));
         let callback = NilCallback;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

make contender easier to instantiate when using as a library

## Solution

`Contender`, `ContenderCtx`, `ContenderCtxBuilder` -- new structs that provide sensible defaults and handle all the heavy lifting required to instantiate and run a spammer.

Example:

```rs
use contender_core::{
    Contender, ContenderCtx, RunOpts,
    generator::{FunctionCallDefinition, types::SpamRequest},
    spammer::{NilCallback, TimedSpammer},
};
use contender_testfile::TestConfig;
use std::time::Duration;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    // optional: enable contender logs
    contender_core::util::init_core_tracing(None);

    // setup test scenario
    let config = TestConfig::new().with_spam(vec![SpamRequest::new_tx(
        &FunctionCallDefinition::new("{_sender}") // send tx to self
            .with_from_pool("spammers"),
    )]);

    // setup contender w/ default settings, may be overridden
    let ctx = ContenderCtx::builder_simple(config, "http://localhost:8545").build();
    let mut contender = Contender::new(ctx);

    // run spammer
    contender
        .spam(
            TimedSpammer::new(Duration::from_secs(1)),
            NilCallback.into(),
            RunOpts::new().txs_per_period(100).periods(20),
        )
        .await?;

    Ok(())
}

```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes