### PR TITLE
feat/block replay

### DIFF
--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -6,7 +6,7 @@ use alloy::primitives::utils::parse_units;
 use alloy::primitives::U256;
 use contender_core::BundleType;
 use contender_engine_provider::reth_node_api::EngineApiMessageVersion;
-use contender_engine_provider::AdvanceChain;
+use contender_engine_provider::ControlChain;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, clap::Args)]
@@ -260,14 +260,15 @@ impl Default for BundleTypeCli {
     }
 }
 
+#[derive(Clone)]
 pub struct EngineParams {
-    pub engine_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    pub engine_provider: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
     pub call_fcu: bool,
 }
 
 impl EngineParams {
     pub fn new(
-        engine_provider: Arc<dyn AdvanceChain + Send + Sync + 'static>,
+        engine_provider: Arc<dyn ControlChain + Send + Sync + 'static>,
         call_forkchoice: bool,
     ) -> Self {
         Self {

--- a/crates/cli/src/commands/contender_subcommand.rs
+++ b/crates/cli/src/commands/contender_subcommand.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 use std::path::PathBuf;
 
 use crate::commands::common::ScenarioSendTxsCliArgs;
+use crate::commands::replay::ReplayCliArgs;
 use crate::default_scenarios::BuiltinScenarioCli;
 
 use super::admin::AdminCommand;
@@ -37,6 +38,15 @@ pub enum ContenderSubcommand {
     Setup {
         #[command(flatten)]
         args: Box<ScenarioSendTxsCliArgs>,
+    },
+
+    #[command(
+        name = "replay",
+        long_about = "Replay a range of blocks with the engine_ API."
+    )]
+    Replay {
+        #[command(flatten)]
+        args: Box<ReplayCliArgs>,
     },
 
     #[command(

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod admin;
 pub mod common;
 mod contender_subcommand;
 pub mod db;
+pub mod replay;
 mod setup;
 mod spam;
 mod spamd;

--- a/crates/cli/src/commands/replay.rs
+++ b/crates/cli/src/commands/replay.rs
@@ -1,0 +1,65 @@
+use std::time::{Duration, Instant};
+
+use crate::commands::common::{AuthCliArgs, EngineParams};
+use contender_core::error::ContenderError;
+use tracing::info;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct ReplayCliArgs {
+    // authenticated engine_ API
+    #[command(flatten)]
+    auth_params: AuthCliArgs,
+
+    /// The first block to start replaying.
+    start_block: u64,
+}
+
+#[derive(Clone)]
+pub struct ReplayArgs {
+    engine_params: EngineParams,
+    start_block: u64,
+}
+
+impl ReplayArgs {
+    pub fn new(engine_params: EngineParams, start_block: u64) -> Self {
+        Self {
+            engine_params,
+            start_block,
+        }
+    }
+
+    pub async fn from_cli_args(args: ReplayCliArgs) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self::new(
+            args.auth_params.engine_params().await?,
+            args.start_block,
+        ))
+    }
+}
+
+pub async fn replay(args: ReplayArgs) -> Result<(), Box<dyn std::error::Error>> {
+    info!("rewinding to block {}...", args.start_block);
+
+    let engine_provider =
+        args.engine_params
+            .engine_provider
+            .ok_or(ContenderError::InvalidRuntimeParams(
+                contender_core::error::RuntimeParamErrorKind::MissingArgs(
+                    "engine_provider is required for replay".to_owned(),
+                ),
+            ))?;
+
+    let start_timestamp = Instant::now();
+    engine_provider
+        .replay_chain_segment(args.start_block)
+        .await?;
+    let time_elapsed = Instant::now().duration_since(start_timestamp);
+
+    let time_elapsed_str = if time_elapsed > Duration::from_secs(1) {
+        format!("{} seconds", time_elapsed.as_secs_f32())
+    } else {
+        format!("{} milliseconds", time_elapsed.as_millis())
+    };
+    info!("finished in {time_elapsed_str}");
+
+    Ok(())
+}

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -276,7 +276,7 @@ impl SetupCommandArgs {
     async fn engine_params(&self) -> contender_core::Result<EngineParams> {
         self.eth_json_rpc_args
             .auth_args
-            .engine_params()
+            .engine_params(self.eth_json_rpc_args.call_forkchoice)
             .await
             .map_err(|e| ContenderError::with_err(e.deref(), "failed to build engine params"))
     }

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -26,10 +26,10 @@ use contender_core::{
     util::get_block_time,
 };
 use contender_engine_provider::{
-    reth_node_api::EngineApiMessageVersion, AdvanceChain, AuthProvider,
+    reth_node_api::EngineApiMessageVersion, AuthProvider, ControlChain,
 };
 use contender_testfile::TestConfig;
-use op_alloy_network::Optimism;
+use op_alloy_network::{Ethereum, Optimism};
 use std::{ops::Deref, path::PathBuf, sync::atomic::AtomicBool};
 use std::{sync::Arc, time::Duration};
 use tracing::{info, warn};
@@ -44,7 +44,7 @@ pub struct EngineArgs {
 
 impl EngineArgs {
     pub async fn new_provider(&self) -> Result<AuthClient, Box<dyn std::error::Error>> {
-        let provider: Box<dyn AdvanceChain + Send + Sync + 'static> = if self.use_op {
+        let provider: Box<dyn ControlChain + Send + Sync + 'static> = if self.use_op {
             Box::new(
                 AuthProvider::<Optimism>::from_jwt_file(
                     &self.auth_rpc_url,
@@ -55,7 +55,7 @@ impl EngineArgs {
             )
         } else {
             Box::new(
-                AuthProvider::<AnyNetwork>::from_jwt_file(
+                AuthProvider::<Ethereum>::from_jwt_file(
                     &self.auth_rpc_url,
                     &self.jwt_secret,
                     self.message_version,

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -151,7 +151,7 @@ impl SpamCommandArgs {
         self.spam_args
             .eth_json_rpc_args
             .auth_args
-            .engine_params()
+            .engine_params(self.spam_args.eth_json_rpc_args.call_forkchoice)
             .await
             .map_err(|e| ContenderError::with_err(e.deref(), "failed to build engine params"))
     }
@@ -535,9 +535,13 @@ pub async fn spam<
         pending_timeout,
         ..
     } = spam_args;
-    let ScenarioSendTxsCliArgs { auth_args, .. } = eth_json_rpc_args;
+    let ScenarioSendTxsCliArgs {
+        auth_args,
+        call_forkchoice,
+        ..
+    } = eth_json_rpc_args;
     let engine_params = auth_args
-        .engine_params()
+        .engine_params(call_forkchoice)
         .await
         .map_err(|e| ContenderError::with_err(e.deref(), "failed to build engine params"))?;
 

--- a/crates/cli/src/default_scenarios/custom_contract.rs
+++ b/crates/cli/src/default_scenarios/custom_contract.rs
@@ -251,7 +251,7 @@ impl CustomContractArgs {
         if let Ok(constructor_sig) = constructor_sig(&abi) {
             contract = contract.with_constructor_args(constructor_sig, &args.constructor_args())?;
         } else {
-            println!("no constructor found");
+            debug!("no constructor found");
         }
 
         // build spam steps

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -24,7 +24,10 @@ use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
 use util::{data_dir, db_file, prompt_continue};
 
-use crate::util::{bold, init_reports_dir};
+use crate::{
+    commands::replay::ReplayArgs,
+    util::{bold, init_reports_dir},
+};
 
 static DB: LazyLock<SqliteDb> = std::sync::LazyLock::new(|| {
     let path = db_file().expect("failed to get DB file path");
@@ -155,6 +158,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             let spamd_args = SpamCommandArgs::new(scenario, *args)?;
             commands::spamd(&db, spamd_args, gen_report, real_loops).await?;
+        }
+
+        ContenderSubcommand::Replay { args } => {
+            let args = ReplayArgs::from_cli_args(*args).await?;
+            commands::replay::replay(args).await?;
         }
 
         ContenderSubcommand::Report {

--- a/crates/cli/src/util/provider.rs
+++ b/crates/cli/src/util/provider.rs
@@ -59,6 +59,11 @@ fn inspect_auth_err(err: &AuthProviderError) {
                     "You may need to add the {} flag to target this node.",
                     bold("--op")
                 )
+            } else if errs.contains("Unsupported fork") {
+                println!(
+                    "You may need to specify a different engine message version with {}",
+                    bold("--message-version (-m)")
+                );
             }
         }
         ConnectionFailed(_) => {

--- a/crates/cli/src/util/provider.rs
+++ b/crates/cli/src/util/provider.rs
@@ -85,9 +85,13 @@ impl AdvanceChain for AuthClient {
 
 #[async_trait]
 impl ReplayChain for AuthClient {
-    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<ChainReplayResults> {
+    async fn replay_chain_segment(
+        &self,
+        start_block: u64,
+        end_block: Option<u64>,
+    ) -> AuthResult<ChainReplayResults> {
         self.auth_provider
-            .replay_chain_segment(start_block)
+            .replay_chain_segment(start_block, end_block)
             .await
             .inspect_err(inspect_auth_err)
     }

--- a/crates/cli/src/util/provider.rs
+++ b/crates/cli/src/util/provider.rs
@@ -1,18 +1,74 @@
 //! Contains a wrapper for auth_provider to handle errors in the cli context.
 
 use async_trait::async_trait;
-use contender_engine_provider::{error::AuthProviderError, AdvanceChain, AuthResult};
+use contender_engine_provider::{
+    error::AuthProviderError, AdvanceChain, AuthResult, ControlChain, ReplayChain,
+};
 use tracing::error;
 
 use crate::util::bold;
 
 pub struct AuthClient {
-    auth_provider: Box<dyn AdvanceChain + Send + Sync + 'static>,
+    auth_provider: Box<dyn ControlChain + Send + Sync + 'static>,
 }
 
 impl AuthClient {
-    pub fn new(auth_provider: Box<dyn AdvanceChain + Send + Sync + 'static>) -> Self {
+    pub fn new(auth_provider: Box<dyn ControlChain + Send + Sync + 'static>) -> Self {
         Self { auth_provider }
+    }
+}
+
+impl ControlChain for AuthClient {}
+
+fn inspect_auth_err(err: &AuthProviderError) {
+    use AuthProviderError::*;
+    match err {
+        MissingBlock(blocknum) => {
+            error!("block number {blocknum} was not found onchain")
+        }
+        InvalidPayload(msg_version, msg) => {
+            error!(
+                "invalid payload (tried message version {:?}): {}",
+                msg_version,
+                msg.unwrap_or_default()
+            );
+            println!("Try changing the message version with {}", bold("-m"));
+        }
+        InvalidTxs => {
+            error!("failed to encode txs in block")
+        }
+        InvalidBlockRange(start, end) => {
+            error!("invalid block range: {start} - {end}")
+        }
+        InvalidBlockStart(blk) => {
+            error!("invalid start block: {blk}")
+        }
+        InternalError(_, err) => {
+            error!("AuthClient encountered an internal error. Please check contender_engine_provider debug logs for more details.");
+            if err.to_string().contains("Invalid newPayload") {
+                println!(
+                    "You may need to specify a different engine message version with {}",
+                    bold("--message-version (-m)")
+                );
+            }
+        }
+        ConnectionFailed(_) => {
+            error!("Failed to connect to the auth API. You may need to enable the auth API on your target node.");
+        }
+        ExtraDataTooShort => {
+            error!("Invalid payload.");
+            println!(
+                "You may need to remove the {} flag to target this node.",
+                bold("--op")
+            );
+        }
+        GasLimitRequired => {
+            error!("Invalid payload.");
+            println!(
+                "You may need to pass the {} flag to target this node.",
+                bold("--op")
+            );
+        }
     }
 }
 
@@ -22,26 +78,16 @@ impl AdvanceChain for AuthClient {
         self.auth_provider
             .advance_chain(block_time)
             .await
-            .inspect_err(|e| {
-                match e {
-                    AuthProviderError::InternalError(_, err) => {
-                        error!("AuthClient encountered an internal error. Please check contender_engine_provider debug logs for more details.");
-                        if err.to_string().contains("Invalid newPayload") {
-                            println!("You may need to specify a different engine message version with {}", bold("--message-version (-m)"));
-                        }
-                    }
-                    AuthProviderError::ConnectionFailed(_) => {
-                        error!("Failed to connect to the auth API. You may need to enable the auth API on your target node.");
-                    }
-                    AuthProviderError::ExtraDataTooShort => {
-                        error!("Invalid payload.");
-                        println!("You may need to remove the {} flag to target this node.", bold("--op"));
-                    }
-                    AuthProviderError::GasLimitRequired => {
-                        error!("Invalid payload.");
-                        println!("You may need to pass the {} flag to target this node.", bold("--op"));
-                    }
-                }
-            })
+            .inspect_err(inspect_auth_err)
+    }
+}
+
+#[async_trait]
+impl ReplayChain for AuthClient {
+    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<()> {
+        self.auth_provider
+            .replay_chain_segment(start_block)
+            .await
+            .inspect_err(inspect_auth_err)
     }
 }

--- a/crates/cli/src/util/provider.rs
+++ b/crates/cli/src/util/provider.rs
@@ -46,11 +46,19 @@ fn inspect_auth_err(err: &AuthProviderError) {
         }
         InternalError(_, err) => {
             error!("AuthClient encountered an internal error. Please check contender_engine_provider debug logs for more details.");
-            if err.to_string().contains("Invalid newPayload") {
+            let errs = err.to_string();
+            if errs.contains("Invalid newPayload") {
                 println!(
                     "You may need to specify a different engine message version with {}",
                     bold("--message-version (-m)")
                 );
+            } else if errs
+                .contains("data did not match any variant of untagged enum BlockTransactions")
+            {
+                println!(
+                    "You may need to add the {} flag to target this node.",
+                    bold("--op")
+                )
             }
         }
         ConnectionFailed(_) => {

--- a/crates/cli/src/util/provider.rs
+++ b/crates/cli/src/util/provider.rs
@@ -2,7 +2,8 @@
 
 use async_trait::async_trait;
 use contender_engine_provider::{
-    error::AuthProviderError, AdvanceChain, AuthResult, ControlChain, ReplayChain,
+    error::AuthProviderError, AdvanceChain, AuthResult, ChainReplayResults, ControlChain,
+    ReplayChain,
 };
 use tracing::error;
 
@@ -84,7 +85,7 @@ impl AdvanceChain for AuthClient {
 
 #[async_trait]
 impl ReplayChain for AuthClient {
-    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<()> {
+    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<ChainReplayResults> {
         self.auth_provider
             .replay_chain_segment(start_block)
             .await

--- a/crates/cli/src/util/utils.rs
+++ b/crates/cli/src/util/utils.rs
@@ -16,7 +16,7 @@ use contender_core::{
     spammer::{LogCallback, NilCallback},
     util::get_blob_fee_maybe,
 };
-use contender_engine_provider::{AdvanceChain, DEFAULT_BLOCK_TIME};
+use contender_engine_provider::{ControlChain, DEFAULT_BLOCK_TIME};
 use contender_testfile::TestConfig;
 use nu_ansi_term::{AnsiGenericString, Color, Style as ANSIStyle};
 use rand::Rng;
@@ -346,7 +346,7 @@ pub fn spam_callback_default(
     log_txs: bool,
     send_fcu: bool,
     rpc_client: Option<Arc<AnyProvider>>,
-    auth_client: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    auth_client: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
     cancel_token: tokio_util::sync::CancellationToken,
 ) -> TypedSpamCallback {
     if let Some(rpc_client) = rpc_client {

--- a/crates/cli/src/util/utils.rs
+++ b/crates/cli/src/util/utils.rs
@@ -480,8 +480,52 @@ pub fn load_seedfile() -> Result<String, Box<dyn std::error::Error>> {
     Ok(stored_seed)
 }
 
+/// Returns a human-readable "gas" string.
+///
+/// ## Example:
+/// ```rs
+/// assert_eq!(human_readable_gas(500), "500 gas");
+/// assert_eq!(human_readable_gas(500_000_000), "500 Mgas");
+/// assert_eq!(human_readable_gas(5_000_000_000), "5 Ggas");
+/// ```
+pub fn human_readable_gas(gas: u128) -> String {
+    let unit_divisors = [
+        ("Ggas", 1_000_000_000.0),
+        ("Mgas", 1_000_000.0),
+        ("Kgas", 1_000.0),
+        ("gas", 1.0),
+    ];
+    let (gas_unit, divisor) = unit_divisors
+        .iter()
+        .find(|(_, divisor)| gas as f64 >= *divisor)
+        .unwrap_or(unit_divisors.last().expect("empty unit_divisors"));
+    format!("{} {gas_unit}", gas as f64 / divisor)
+}
+
+/// Returns a human-readable duration, which only goes up to minutes.
+/// Doesn't display minutes until >2 minutes have elapsed.
+///
+/// ## Example:
+/// ```rs
+/// assert_eq!(human_readable_duration(Duration::from_secs(60)), "60 seconds");
+/// assert_eq!(human_readable_duration(Duration::from_secs(240)), "4 minutes");
+/// assert_eq!(human_readable_duration(Duration::from_millis(600)), "600 milliseconds");
+/// ```
+pub fn human_readable_duration(duration: Duration) -> String {
+    if duration > Duration::from_secs(60 * 2) {
+        format!("{} minutes", duration.as_secs_f32() / 60.0)
+    } else if duration > Duration::from_secs(1) {
+        format!("{} seconds", duration.as_secs_f32())
+    } else {
+        format!("{} milliseconds", duration.as_millis())
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use crate::util::human_readable_duration;
+    use crate::util::utils::human_readable_gas;
+
     use super::fund_accounts;
     use super::load_testconfig;
     use super::parse_duration;
@@ -672,5 +716,29 @@ mod test {
         .await;
         println!("res: {res:?}");
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn human_readable_gas_works() {
+        assert_eq!(human_readable_gas(500), "500 gas");
+        assert_eq!(human_readable_gas(500_000_000), "500 Mgas");
+        assert_eq!(human_readable_gas(5_000_000_000), "5 Ggas");
+        assert_eq!(human_readable_gas(5_101_000_000), "5.101 Ggas");
+    }
+
+    #[test]
+    fn human_readable_duration_works() {
+        assert_eq!(
+            human_readable_duration(Duration::from_secs(60)),
+            "60 seconds"
+        );
+        assert_eq!(
+            human_readable_duration(Duration::from_secs(240)),
+            "4 minutes"
+        );
+        assert_eq!(
+            human_readable_duration(Duration::from_millis(600)),
+            "600 milliseconds"
+        );
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -100,18 +100,28 @@ impl From<BundleProviderError> for ContenderError {
 
 impl From<AuthProviderError> for ContenderError {
     fn from(err: AuthProviderError) -> ContenderError {
+        use AuthProviderError::*;
         match err {
-            AuthProviderError::InternalError(msg, e) => {
+            InvalidPayload(_, _) => ContenderError::with_err(err, "invalid payload"),
+            MissingBlock(_) => ContenderError::with_err(err, "block not found onchain"),
+            InvalidTxs => ContenderError::with_err(err, "invalid txs in block"),
+            InvalidBlockRange(start, end) => ContenderError::InvalidRuntimeParams(
+                RuntimeParamErrorKind::InvalidArgs(format!("start={start}, end={end}")),
+            ),
+            InvalidBlockStart(blk) => ContenderError::InvalidRuntimeParams(
+                RuntimeParamErrorKind::InvalidArgs(format!("start={blk}")),
+            ),
+            InternalError(msg, e) => {
                 ContenderError::AdminError(msg.unwrap_or("internal error"), e.to_string())
             }
-            AuthProviderError::ConnectionFailed(e) => {
+            ConnectionFailed(e) => {
                 ContenderError::AdminError("Failed to connect to auth provider", e.to_string())
             }
-            AuthProviderError::ExtraDataTooShort => ContenderError::AdminError(
+            ExtraDataTooShort => ContenderError::AdminError(
                 "Extra data too short",
                 "Genesis block extra data is too short".to_string(),
             ),
-            AuthProviderError::GasLimitRequired => ContenderError::AdminError(
+            GasLimitRequired => ContenderError::AdminError(
                 "Gas limit required",
                 "Gas limit parameter is required".to_string(),
             ),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -112,10 +112,10 @@ impl From<AuthProviderError> for ContenderError {
                 RuntimeParamErrorKind::InvalidArgs(format!("start={blk}")),
             ),
             InternalError(msg, e) => {
-                ContenderError::AdminError(msg.unwrap_or("internal error"), e.to_string())
+                ContenderError::with_err(e.deref(), msg.unwrap_or("internal error"))
             }
             ConnectionFailed(e) => {
-                ContenderError::AdminError("Failed to connect to auth provider", e.to_string())
+                ContenderError::with_err(e.deref(), "Failed to connect to auth provider")
             }
             ExtraDataTooShort => ContenderError::AdminError(
                 "Extra data too short",

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -23,7 +23,7 @@ use alloy::{
     signers::local::PrivateKeySigner, transports::http::reqwest::Url,
 };
 use contender_bundle_provider::bundle::BundleType;
-use contender_engine_provider::AdvanceChain;
+use contender_engine_provider::ControlChain;
 use std::sync::LazyLock;
 
 static SMOL_AMOUNT: LazyLock<U256> = LazyLock::new(|| WEI_IN_ETHER / U256::from(100));
@@ -50,7 +50,7 @@ where
     pub bundle_type: BundleType,
     pub pending_tx_timeout_secs: u64,
     pub extra_msg_handles: Option<HashMap<String, Arc<TxActorHandle>>>,
-    pub auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    pub auth_provider: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
     pub prometheus: PrometheusCollector,
     /// The amount of ether each agent account gets.
     pub funding: U256,
@@ -240,7 +240,7 @@ where
     bundle_type: BundleType,
     pending_tx_timeout_secs: u64,
     extra_msg_handles: Option<HashMap<String, Arc<TxActorHandle>>>,
-    auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    auth_provider: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
     prometheus: PrometheusCollector,
     funding: U256,
     redeploy: bool,
@@ -280,7 +280,7 @@ where
         self.extra_msg_handles = Some(m);
         self
     }
-    pub fn auth_provider(mut self, a: Arc<dyn AdvanceChain + Send + Sync + 'static>) -> Self {
+    pub fn auth_provider(mut self, a: Arc<dyn ControlChain + Send + Sync + 'static>) -> Self {
         self.auth_provider = Some(a);
         self
     }

--- a/crates/core/src/spammer/tx_callback.rs
+++ b/crates/core/src/spammer/tx_callback.rs
@@ -4,7 +4,7 @@ use crate::{
     generator::{types::AnyProvider, NamedTxRequest},
 };
 use alloy::providers::PendingTransactionConfig;
-use contender_engine_provider::{AdvanceChain, DEFAULT_BLOCK_TIME};
+use contender_engine_provider::{ControlChain, DEFAULT_BLOCK_TIME};
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -95,7 +95,7 @@ pub struct NilCallback;
 
 pub struct LogCallback {
     pub rpc_provider: Arc<AnyProvider>,
-    pub auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    pub auth_provider: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
     pub send_fcu: bool,
     pub cancel_token: tokio_util::sync::CancellationToken,
 }
@@ -111,7 +111,7 @@ impl LogCallback {
     }
     pub fn auth_provider(
         mut self,
-        provider: Arc<dyn AdvanceChain + Send + Sync + 'static>,
+        provider: Arc<dyn ControlChain + Send + Sync + 'static>,
     ) -> Self {
         self.auth_provider = Some(provider);
         self

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -33,7 +33,7 @@ use contender_bundle_provider::bundle::BundleType;
 use contender_bundle_provider::bundle_provider::new_basic_bundle;
 use contender_bundle_provider::revert_bundle::RevertProtectBundleRequest;
 use contender_bundle_provider::BundleClient;
-use contender_engine_provider::AdvanceChain;
+use contender_engine_provider::ControlChain;
 use futures::{Stream, StreamExt};
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
@@ -90,7 +90,7 @@ where
     pub db: Arc<D>,
     pub rpc_url: Url,
     pub builder_rpc_url: Option<Url>,
-    pub auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+    pub auth_provider: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
     pub bundle_client: Option<Arc<BundleClient>>,
     pub rpc_client: Arc<AnyProvider>,
     pub rand_seed: S,
@@ -166,7 +166,7 @@ where
         db: Arc<D>,
         rand_seed: S,
         params: TestScenarioParams,
-        auth_provider: Option<Arc<dyn AdvanceChain + Send + Sync + 'static>>,
+        auth_provider: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
         prometheus: PrometheusCollector,
     ) -> Result<Self> {
         let TestScenarioParams {

--- a/crates/engine_provider/src/auth_provider.rs
+++ b/crates/engine_provider/src/auth_provider.rs
@@ -468,11 +468,15 @@ impl<N: Network + NetworkAttributes> AdvanceChain for AuthProvider<N> {
 
 #[async_trait]
 impl ReplayChain for AuthProvider<Ethereum> {
-    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<ChainReplayResults> {
+    async fn replay_chain_segment(
+        &self,
+        start_block: u64,
+        end_block: Option<u64>,
+    ) -> AuthResult<ChainReplayResults> {
         let engine_client = &self.inner;
 
         // check block range
-        let blocknum_head = engine_client.get_block_number().await?;
+        let blocknum_head = end_block.unwrap_or(engine_client.get_block_number().await?);
         if start_block >= blocknum_head {
             return Err(AuthProviderError::InvalidBlockRange(
                 start_block,
@@ -549,7 +553,11 @@ impl ReplayChain for AuthProvider<Ethereum> {
 
 #[async_trait]
 impl ReplayChain for AuthProvider<Optimism> {
-    async fn replay_chain_segment(&self, _start_block: u64) -> AuthResult<ChainReplayResults> {
+    async fn replay_chain_segment(
+        &self,
+        _start_block: u64,
+        _end_block: Option<u64>,
+    ) -> AuthResult<ChainReplayResults> {
         todo!()
     }
 }

--- a/crates/engine_provider/src/error.rs
+++ b/crates/engine_provider/src/error.rs
@@ -2,9 +2,15 @@ use std::fmt::Display;
 
 use alloy::transports::TransportErrorKind;
 use alloy_json_rpc::RpcError;
+use reth_node_api::EngineApiMessageVersion;
 
 #[derive(Debug)]
 pub enum AuthProviderError {
+    MissingBlock(u64),
+    InvalidTxs,
+    InvalidBlockRange(u64, u64),
+    InvalidBlockStart(u64),
+    InvalidPayload(EngineApiMessageVersion, Option<&'static str>),
     InternalError(Option<&'static str>, Box<dyn std::error::Error>),
     ConnectionFailed(Box<dyn std::error::Error>),
     ExtraDataTooShort,
@@ -15,21 +21,42 @@ impl std::error::Error for AuthProviderError {}
 
 impl Display for AuthProviderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use AuthProviderError::*;
         match self {
-            AuthProviderError::InternalError(m, e) => {
+            InvalidPayload(msg_version, msg) => {
+                write!(
+                    f,
+                    "invalid payload: tried sending message version {:?}. {}",
+                    msg_version,
+                    msg.unwrap_or_default()
+                )
+            }
+            MissingBlock(blocknum) => {
+                write!(f, "failed to retrieve block {blocknum} from the RPC")
+            }
+            InvalidTxs => {
+                write!(f, "block must include full txs")
+            }
+            InvalidBlockStart(start_block) => {
+                write!(f, "invalid start block, must be > 1 (tried {start_block})")
+            }
+            InvalidBlockRange(start_block, end_block) => {
+                write!(f, "invalid block range; start block ({start_block} must be behind the chain head ({end_block})")
+            }
+            InternalError(m, e) => {
                 if let Some(m) = m {
                     write!(f, "internal error ({m}): {e}")
                 } else {
                     write!(f, "internal error: {e}")
                 }
             }
-            AuthProviderError::ConnectionFailed(e) => {
+            ConnectionFailed(e) => {
                 write!(f, "failed to connect to auth provider: {e}")
             }
-            AuthProviderError::ExtraDataTooShort => {
+            ExtraDataTooShort => {
                 write!(f, "extra_data of genesis block is too short")
             }
-            AuthProviderError::GasLimitRequired => write!(f, "gasLimit parameter is required"),
+            GasLimitRequired => write!(f, "gasLimit parameter is required"),
         }
     }
 }

--- a/crates/engine_provider/src/lib.rs
+++ b/crates/engine_provider/src/lib.rs
@@ -2,12 +2,13 @@ mod auth_provider;
 mod auth_transport;
 pub mod engine;
 pub mod error;
+// mod payload_builder;
 mod traits;
 mod util;
 mod valid_payload;
 
 pub use auth_provider::{AuthProvider, AuthResult, ProviderExt};
-pub use traits::AdvanceChain;
+pub use traits::*;
 pub use util::*;
 
 pub use reth_node_api;

--- a/crates/engine_provider/src/lib.rs
+++ b/crates/engine_provider/src/lib.rs
@@ -2,8 +2,8 @@ mod auth_provider;
 mod auth_transport;
 pub mod engine;
 pub mod error;
-// mod payload_builder;
 mod traits;
+mod tx_adapter;
 mod util;
 mod valid_payload;
 

--- a/crates/engine_provider/src/traits.rs
+++ b/crates/engine_provider/src/traits.rs
@@ -32,7 +32,11 @@ impl ChainReplayResults {
 pub trait ReplayChain {
     /// Re-send & re-validate a range of previously-committed blocks.
     /// Returns relevant results from the replay execution.
-    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<ChainReplayResults>;
+    async fn replay_chain_segment(
+        &self,
+        start_block: u64,
+        end_block: Option<u64>,
+    ) -> AuthResult<ChainReplayResults>;
 }
 
 pub trait ControlChain: AdvanceChain + ReplayChain {}

--- a/crates/engine_provider/src/traits.rs
+++ b/crates/engine_provider/src/traits.rs
@@ -1,3 +1,4 @@
+use alloy_rpc_types_engine::ExecutionPayload;
 use async_trait::async_trait;
 
 use crate::auth_provider::AuthResult;
@@ -6,4 +7,16 @@ use crate::auth_provider::AuthResult;
 pub trait AdvanceChain {
     /// Advance the chain by calling `engine_forkchoiceUpdated` (FCU) and `engine_newPayload` methods.
     async fn advance_chain(&self, block_time_secs: u64) -> AuthResult<()>;
+}
+
+#[async_trait]
+pub trait ReplayChain {
+    /// Re-send & re-validate a range of previously-committed blocks.
+    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<()>;
+}
+
+pub trait ControlChain: AdvanceChain + ReplayChain {}
+
+pub trait ToExecutionPayload {
+    fn to_payload(&self) -> AuthResult<ExecutionPayload>;
 }

--- a/crates/engine_provider/src/traits.rs
+++ b/crates/engine_provider/src/traits.rs
@@ -1,10 +1,14 @@
 use std::time::Duration;
 
+use alloy::{
+    consensus::{transaction::TxHashRef, Transaction},
+    primitives::Bytes,
+};
 use alloy_rpc_types_engine::ExecutionPayload;
 use async_trait::async_trait;
 use tracing::warn;
 
-use crate::auth_provider::AuthResult;
+use crate::auth_provider::{AuthResult, OpPayloadParams};
 
 #[async_trait]
 pub trait AdvanceChain {
@@ -41,6 +45,20 @@ pub trait ReplayChain {
 
 pub trait ControlChain: AdvanceChain + ReplayChain {}
 
-pub trait ToExecutionPayload {
-    fn to_payload(&self) -> AuthResult<ExecutionPayload>;
+#[async_trait]
+pub trait BlockToPayload {
+    async fn block_to_payload(&self, block_num: u64) -> AuthResult<ExecutionPayload>;
+}
+
+pub trait TxEnvelopeTransformer {
+    fn to_envelope(&self) -> impl Transaction + TxHashRef;
+}
+
+pub trait FcuDefault: reth_node_api::PayloadAttributes + Send + Sync {
+    fn fcu_payload_attributes(timestamp: u64, op_params: Option<OpPayloadParams>) -> Self;
+}
+
+pub trait DefaultTxEncoding {
+    type Tx;
+    fn encode_tx(tx: Self::Tx) -> Bytes;
 }

--- a/crates/engine_provider/src/traits.rs
+++ b/crates/engine_provider/src/traits.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
 use alloy_rpc_types_engine::ExecutionPayload;
 use async_trait::async_trait;
+use tracing::warn;
 
 use crate::auth_provider::AuthResult;
 
@@ -9,10 +12,27 @@ pub trait AdvanceChain {
     async fn advance_chain(&self, block_time_secs: u64) -> AuthResult<()>;
 }
 
+#[derive(Clone, Debug)]
+pub struct ChainReplayResults {
+    pub gas_used: u128,
+    pub time_elapsed: Duration,
+}
+
+impl ChainReplayResults {
+    /// Returns the average execution speed in gas/second.
+    pub fn gas_per_second(&self) -> u128 {
+        if self.gas_used == 0 {
+            warn!("no gas was used; the block may be empty.");
+        }
+        self.gas_used / self.time_elapsed.as_secs().max(1) as u128
+    }
+}
+
 #[async_trait]
 pub trait ReplayChain {
     /// Re-send & re-validate a range of previously-committed blocks.
-    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<()>;
+    /// Returns relevant results from the replay execution.
+    async fn replay_chain_segment(&self, start_block: u64) -> AuthResult<ChainReplayResults>;
 }
 
 pub trait ControlChain: AdvanceChain + ReplayChain {}

--- a/crates/engine_provider/src/tx_adapter.rs
+++ b/crates/engine_provider/src/tx_adapter.rs
@@ -1,0 +1,70 @@
+use alloy::consensus::Transaction;
+use alloy::eips::Encodable2718;
+use alloy::primitives::B256;
+use alloy::{
+    consensus::TxEnvelope,
+    primitives::{Bytes, FixedBytes},
+    rpc::types::eth,
+};
+use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_network::TransactionResponse;
+use op_alloy_rpc_types as op;
+
+use crate::TxLike;
+
+pub enum AnyTx {
+    Eth(eth::Transaction),
+    Op(op::Transaction),
+}
+
+impl From<eth::Transaction> for AnyTx {
+    fn from(t: eth::Transaction) -> Self {
+        AnyTx::Eth(t)
+    }
+}
+impl From<op::Transaction> for AnyTx {
+    fn from(t: op::Transaction) -> Self {
+        AnyTx::Op(t)
+    }
+}
+
+impl TxLike for AnyTx {
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        use AnyTx::*;
+        match self {
+            Eth(t) => t.blob_versioned_hashes(),
+            Op(t) => t.blob_versioned_hashes(),
+        }
+    }
+
+    fn tx_hash(&self) -> FixedBytes<32> {
+        use AnyTx::*;
+        match self {
+            Eth(t) => {
+                // ETH RPC tx implements AsRef<TxEnvelope>
+                let env: &TxEnvelope = t.as_ref();
+                *env.tx_hash() // via `TxHashRef`
+            }
+            Op(t) => {
+                // OP RPC tx exposes its own hash; use that.
+                t.tx_hash()
+            }
+        }
+    }
+
+    fn encoded_2718(&self) -> Bytes {
+        use AnyTx::*;
+        match self {
+            Eth(t) => {
+                let env: &TxEnvelope = t.as_ref();
+                Bytes::from(env.encoded_2718())
+            }
+            Op(t) => {
+                // OP has deposit txs (non-ETH 2718). For Engine payloads on OP,
+                // you still pass the canonical OP tx bytes. OP’s envelope encodes them.
+                let env: &OpTxEnvelope = t.as_ref(); // OP RPC tx → OpTxEnvelope
+                Bytes::from(env.encoded_2718())
+            }
+        }
+    }
+}

--- a/crates/engine_provider/src/valid_payload.rs
+++ b/crates/engine_provider/src/valid_payload.rs
@@ -3,9 +3,10 @@
 //! before sending additional calls.
 
 use crate::{auth_provider::NetworkAttributes, engine::EngineApi};
+use alloy::eips::eip7685::RequestsOrHash;
+use alloy::primitives::B256;
 use alloy::providers::Network;
 use alloy::transports::TransportResult;
-use alloy::{eips::eip7685::Requests, primitives::B256};
 use alloy_rpc_types_engine::{
     ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV3, ForkchoiceState,
     ForkchoiceUpdated, PayloadStatus,
@@ -45,7 +46,7 @@ pub trait EngineApiValidWaitExt<N: NetworkAttributes>: Send + Sync {
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
-        execution_requests: Requests,
+        execution_requests: RequestsOrHash,
     ) -> TransportResult<PayloadStatus>;
 
     /// Calls `engine_forkChoiceUpdatedV1` with the given [ForkchoiceState] and optional
@@ -160,7 +161,7 @@ where
         payload: ExecutionPayloadV3,
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
-        execution_requests: Requests,
+        execution_requests: RequestsOrHash,
     ) -> TransportResult<PayloadStatus> {
         let mut status = self
             .new_payload_v4(


### PR DESCRIPTION
## Motivation

resolves https://github.com/flashbots/contender/issues/270

## Solution

- new trait `ReplayChain` with a function `replay_chain_segment` implemented for `AuthProvider<Ethereum | Optimism>`
- trait implementations via macros to keep trait implementations DRY across different `Network` impls

new command `contender replay`:

- requires `--auth-rpc` and `--jwt` to connect to auth API
- all other flags optional (will start at block 1 and replay up to present if `--from` & `--to` aren't specified.
- compatible with op-geth; pass `--op`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes